### PR TITLE
feat(#22): プロポーザル検索機能の追加

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -82,8 +82,13 @@ initial_prompt: ""
 # the name by which the project can be referenced within Serena
 project_name: "se-masked-quiz"
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
 # The full set of modes to be activated is base_modes + default_modes.
@@ -100,10 +105,6 @@ base_modes:
 # This setting can, in turn, be overridden by CLI parameters (--mode).
 default_modes:
 
-# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
-# This cannot be combined with non-empty excluded_tools or included_optional_tools.
-fixed_tools: []
-
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.
@@ -117,11 +118,25 @@ symbol_info_budget:
 # is activated post-init, an error will be returned.
 language_backend:
 
-# list of regex patterns which, when matched, mark a memory entry as read‑only.
-# Extends the list from the global configuration, merging the two lists.
-read_only_memory_patterns: []
-
 # line ending convention to use when writing source files.
 # Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
 # This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
 line_ending:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/ios/se-masked-quiz/EnvSample.swift
+++ b/ios/se-masked-quiz/EnvSample.swift
@@ -11,6 +11,10 @@
       ""
     }
 
+    static var microCmsReadOnlyApiKey: String {
+      ""
+    }
+
     static var microCmsApiEndpoint: String {
       ""
     }

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -17,6 +17,9 @@ struct ProposalListScreen: View {
   @State private var showsSetting: Bool = false
   @State private var quizProgresses: [String: ProposalProgress] = [:]
   @State private var isLoadingProgress: Bool = false
+  @State private var searchText: String = ""
+  @State private var activeQuery: String = ""
+  @State private var searchTask: Task<Void, Never>?
 
   var body: some View {
     GeometryReader { proxy in
@@ -60,6 +63,43 @@ struct ProposalListScreen: View {
             quizRepository: quizRepository
           )
         }
+        .overlay {
+          if !proposals.isLoading && proposals.content.isEmpty && !activeQuery.isEmpty {
+            ContentUnavailableView.search(text: activeQuery)
+          }
+        }
+        .searchable(text: $searchText, prompt: "プロポーザルを検索")
+        .onSubmit(of: .search) {
+          searchTask?.cancel()
+          activeQuery = searchText
+        }
+        .onChange(of: searchText) { _, newValue in
+          searchTask?.cancel()
+          searchTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            activeQuery = newValue
+          }
+        }
+        .onChange(of: activeQuery) { _, newQuery in
+          offset = 0
+          shouldLoadNextPage = false
+          proposals = .idle
+
+          Task {
+            proposals.startLoading()
+            do {
+              let query = newQuery.isEmpty ? nil : newQuery
+              let results = try await repository.fetch(offset: 0, query: query)
+              offset = results.count
+              proposals = .loaded(results)
+            } catch {
+              if !Task.isCancelled {
+                proposals = .error(error)
+              }
+            }
+          }
+        }
         .toolbar {
           #if os(iOS)
             ToolbarItem(placement: .topBarLeading) {
@@ -93,7 +133,8 @@ struct ProposalListScreen: View {
             proposals.startLoading()
             Task {
               do {
-                let newProposals = try await repository.fetch(offset: offset)
+                let query = activeQuery.isEmpty ? nil : activeQuery
+                let newProposals = try await repository.fetch(offset: offset, query: query)
                 var currentProposals = proposals.content
                 currentProposals.append(contentsOf: newProposals)
                 proposals = .loaded(currentProposals)

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -9,15 +9,29 @@ import Foundation
 import SwiftUI
 
 struct SERepository: Sendable {
-  func fetch(offset: Int) async throws -> [SwiftEvolution] {
-    let microCmsApiKey = Env.microCmsApiKey
+  func fetch(offset: Int, query: String? = nil) async throws -> [SwiftEvolution] {
+    let microCmsReadOnlyApiKey = Env.microCmsReadOnlyApiKey
     let microCmsApiEndpoint = Env.microCmsApiEndpoint
-    let requestURL = URL(
-      string: "https://\(microCmsApiEndpoint).microcms.io/api/v1/proposals?offset=\(offset)")!
+
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "\(microCmsApiEndpoint).microcms.io"
+    components.path = "/api/v1/proposals"
+
+    var queryItems = [URLQueryItem(name: "offset", value: "\(offset)")]
+    if let query, !query.isEmpty {
+      queryItems.append(URLQueryItem(name: "q", value: query))
+    }
+    components.queryItems = queryItems
+
+    guard let requestURL = components.url else {
+      throw URLError(.badURL)
+    }
+
     var request = URLRequest(url: requestURL)
     request.httpMethod = "GET"
     request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue(microCmsApiKey, forHTTPHeaderField: "X-MICROCMS-API-KEY")
+    request.setValue(microCmsReadOnlyApiKey, forHTTPHeaderField: "X-MICROCMS-API-KEY")
     let (data, _) = try await URLSession.shared.data(for: request)
     let decoder = JSONDecoder()
     let response = try decoder.decode(FetchResponse.self, from: data)


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## Summary

Closes #22

MicroCMS APIの`q`パラメータを利用したサーバーサイド全文検索をプロポーザル一覧に追加します。

## 主要な変更点

- **`EnvSample.swift`**: 読み取り専用APIキー（`microCmsReadOnlyApiKey`）を追加
- **`SERepository.swift`**: `fetch(offset:query:)`にクエリパラメータ追加、URL構築を`URLComponents`に変更して安全なエンコーディングに対応
- **`ProposalListScreen.swift`**: SwiftUIの`.searchable()`修飾子による検索バー追加、300msデバウンス、検索結果なし時の`ContentUnavailableView`表示、ページネーション対応

## 動作

- 検索バーにテキスト入力 → 300ms後にMicroCMS APIで全文検索
- Enter押下 → 即座に検索実行
- 検索クリア → 元のページネーション付き一覧に復元
- 検索結果0件 → 「該当するプロポーザルが見つかりません」表示
- 検索結果内のスクロール → ページネーションが機能

## 注意事項

ローカルの`Env.swift`（gitignore対象）にも`microCmsReadOnlyApiKey`プロパティを追加し、MicroCMSの読み取り専用APIキーを設定する必要があります。

## テスト

- [x] `xcodebuild build` 成功確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)