### PR TITLE
feat(#25): Payload ログインにロックアウト設定を追加

### DIFF
--- a/server/src/collections/Users.ts
+++ b/server/src/collections/Users.ts
@@ -7,6 +7,8 @@ export const Users: CollectionConfig = {
   },
   auth: {
     useAPIKey: true,
+    maxLoginAttempts: 5,
+    lockTime: 10 * 60 * 1000,
   },
   fields: [],
 }


### PR DESCRIPTION
## 概要

Payload CMS の Users コレクションに連続ログイン失敗時のロックアウトを設定し、パスワードリスト攻撃 (credential stuffing / brute force) に対する耐性を強化します。

`/admin` への Basic Auth ゲートは既に導入済みですが、その先の Payload ログイン (email + password) 自体は無防備でした。本 PR は防御層を 1 段追加します。

## 背景

`swift-evolution-masking` リポの CI (`mask-and-upload`) が `403 Forbidden` で失敗していた件 (PAYLOAD_SECRET タイポ起因) の調査の中で、本番 admin の認証経路を見直しました。Worker secret を整理したついでに、Payload ログイン経路の攻撃耐性も底上げします。

## 主要な変更点

`server/src/collections/Users.ts` の `auth` に以下を追加:

```ts
auth: {
  useAPIKey: true,
  maxLoginAttempts: 5,        // 5 回連続失敗で
  lockTime: 10 * 60 * 1000,   // 10 分間ロック (ms)
}
```

- DB スキーマには既存マイグレーション (`server/src/migrations/20260505_065448.ts:16-17`) で `users.login_attempts` / `users.lock_until` カラムが存在 → **追加マイグレーション不要**
- Worker は本 PR コミット時点のコードで再デプロイ済み (Version `486949d4-8dc2-4bb9-95a0-e7999381d5a5`) のため、production には既に反映済み

`server/package.json`: corepack による `packageManager` フィールドの自動付与 (pnpm 操作で再現するため同一コミットに含む。機能変更ではない)

## テストの実行状況

- [x] `pnpm run deploy` 成功確認 (Worker upload + custom domain trigger 反映)
- [x] 本番 `/admin` Basic Auth → Payload ログイン → API Key Regenerate の経路が動くことを確認
- [x] `swift-evolution-masking` ワークフローの 403 が解消することを確認 (別件: GitHub Secret `PAYLOAD_API_KEY` 更新による)

## レビューポイント

- `maxLoginAttempts: 5` / `lockTime: 10min` の閾値は Payload デフォルト相当の妥当値ですが、運用上の体感に応じて調整余地あり
- ロックアウトは email 単位で記録されます (`users.login_attempts`)。IP 単位のレート制限は Cloudflare Rate Limiting (別作業) で補完予定

## 関連

- 元 issue: #25 (Payload CMS 移行)
- 関連 PR: #28 (Payload deploy 修正)

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->