### PR TITLE
fix(#25): proposals.content の maxLength を 500,000 に拡張

### DIFF
--- a/server/src/collections/Proposals.ts
+++ b/server/src/collections/Proposals.ts
@@ -33,6 +33,7 @@ export const Proposals: CollectionConfig = {
       name: 'content',
       type: 'textarea',
       required: true,
+      maxLength: 500_000,
     },
     {
       name: 'reviewManager',


### PR DESCRIPTION
## 概要

Payload CMS の `proposals` コレクションで `content` フィールドの `maxLength` を `500_000` に明示する。

## 背景・問題

`mask_and_upload` ワークフローで proposal 0529 のアップロードが 400 エラーで失敗していた。

```
{"errors":[{"name":"h2","data":{"collection":"proposals",
 "errors":[{"label":"Content","message":"This value must be shorter than the max length of 40000 characters.","path":"content"}]},
 "message":"The following field is invalid: Content"}]}
```

原因: `content` は `type: 'textarea'` だが `maxLength` を明示していないため、Payload v3 の textarea デフォルト 40,000 文字制限が適用されていた。

- 0529-filepath-in-stdlib.md: 54,836 B（既に上限超過）
- 最大 proposal (0344-distributed-actor-runtime.md): 125,400 B
- HTML 変換でさらに膨張するため、十分な余裕を確保する必要があった

## 主な変更点

- `server/src/collections/Proposals.ts` の `content` フィールドに `maxLength: 500_000` を追加

## 上限の根拠

- 現状最大 (0344) の Markdown 125 KB → HTML 化で 1.3〜1.6x 想定 → 〜200 KB
- D1 (SQLite) の TEXT 型は実質無制限なのでストレージ的に問題なし
- 500 KB バッファで近い将来の長尺 proposal でも再発しない

## レビューポイント

- 上限値 500,000 が妥当か（過剰/過少でないか）
- 既存データ（短い proposal）に対する後方互換性に問題がないか

## テスト状況

- ローカルでのフィールド型整合性は Payload v3 のドキュメント・型定義に基づき確認済み
- 実機検証は本番デプロイ後に GitHub Actions の `mask_and_upload` 再実行で確認予定

## 関連

- Refs #25 (Payload CMS 移行)

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->