### PR TITLE
feat: 提案一覧を提案番号で昇順/降順に切り替えられるようにする (#33)

### DIFF
--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -20,7 +20,7 @@ struct ProposalListScreen: View {
   @State private var isLoadingProgress: Bool = false
   @State private var searchText: String = ""
   @State private var debouncedSearchText: String = ""
-  @State private var sortOrder: ProposalSortOrder = .ascending
+  @State private var sortOrder: ProposalSortOrder = .descending
 
   var body: some View {
     GeometryReader { proxy in

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -20,6 +20,7 @@ struct ProposalListScreen: View {
   @State private var isLoadingProgress: Bool = false
   @State private var searchText: String = ""
   @State private var debouncedSearchText: String = ""
+  @State private var sortOrder: ProposalSortOrder = .ascending
 
   var body: some View {
     GeometryReader { proxy in
@@ -41,7 +42,8 @@ struct ProposalListScreen: View {
               do {
                 let response = try await repository.fetch(
                   page: currentPage,
-                  searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText
+                  searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText,
+                  sortOrder: sortOrder
                 )
                 hasNextPage = response.hasNextPage
                 var currentProposals = proposals.content
@@ -61,22 +63,10 @@ struct ProposalListScreen: View {
         debouncedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
       }
       .onChange(of: debouncedSearchText) { _, newValue in
-        currentPage = 1
-        hasNextPage = true
-        proposals = .loading([])
-        Task {
-          do {
-            let response = try await repository.fetch(
-              page: currentPage,
-              searchText: newValue.isEmpty ? nil : newValue
-            )
-            hasNextPage = response.hasNextPage
-            proposals = .loaded(response.docs.map { $0.toSwiftEvolution() })
-            currentPage += 1
-          } catch {
-            proposals = .error(error)
-          }
-        }
+        reloadFromFirstPage(searchText: newValue, sortOrder: sortOrder)
+      }
+      .onChange(of: sortOrder) { _, newValue in
+        reloadFromFirstPage(searchText: debouncedSearchText, sortOrder: newValue)
       }
       .task {
         if !proposals.content.isEmpty || proposals.isLoading {
@@ -84,7 +74,7 @@ struct ProposalListScreen: View {
         }
         do {
           proposals.startLoading()
-          let response = try await repository.fetch(page: currentPage)
+          let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder)
           hasNextPage = response.hasNextPage
           self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution() })
           currentPage += 1
@@ -197,6 +187,9 @@ struct ProposalListScreen: View {
             Image(systemName: "gearshape")
           }
         }
+        ToolbarItem(placement: .topBarTrailing) {
+          sortMenu
+        }
       #elseif os(macOS)
         ToolbarItem(placement: .navigation) {
           Button {
@@ -205,11 +198,46 @@ struct ProposalListScreen: View {
             Image(systemName: "gearshape")
           }
         }
+        ToolbarItem(placement: .primaryAction) {
+          sortMenu
+        }
       #endif
     }
   }
 
+  private var sortMenu: some View {
+    Menu {
+      Picker("並び順", selection: $sortOrder) {
+        Label("提案番号 昇順", systemImage: "arrow.up").tag(ProposalSortOrder.ascending)
+        Label("提案番号 降順", systemImage: "arrow.down").tag(ProposalSortOrder.descending)
+      }
+    } label: {
+      Image(systemName: "arrow.up.arrow.down")
+        .accessibilityLabel("並び順")
+    }
+  }
+
   // MARK: - Private Methods
+
+  private func reloadFromFirstPage(searchText: String, sortOrder: ProposalSortOrder) {
+    currentPage = 1
+    hasNextPage = true
+    proposals = .loading([])
+    Task {
+      do {
+        let response = try await repository.fetch(
+          page: currentPage,
+          searchText: searchText.isEmpty ? nil : searchText,
+          sortOrder: sortOrder
+        )
+        hasNextPage = response.hasNextPage
+        proposals = .loaded(response.docs.map { $0.toSwiftEvolution() })
+        currentPage += 1
+      } catch {
+        proposals = .error(error)
+      }
+    }
+  }
 
   /// クイズの進捗情報を読み込む
   private func loadQuizProgresses() async {

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -48,7 +48,7 @@ struct SERepository: Sendable {
   func fetch(
     page: Int,
     searchText: String? = nil,
-    sortOrder: ProposalSortOrder = .ascending
+    sortOrder: ProposalSortOrder = .descending
   ) async throws -> PayloadListResponse<PayloadProposal> {
     let baseURL = Env.serverBaseURL
     let apiKey = Env.serverApiKey
@@ -86,7 +86,7 @@ struct SERepository: Sendable {
     page: Int,
     limit: Int,
     searchText: String? = nil,
-    sortOrder: ProposalSortOrder = .ascending
+    sortOrder: ProposalSortOrder = .descending
   ) throws -> URL {
     var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     while trimmed.hasSuffix("/") {

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -8,6 +8,20 @@
 import Foundation
 import SwiftUI
 
+enum ProposalSortOrder: String, CaseIterable, Sendable, Hashable {
+  case ascending
+  case descending
+
+  var queryValue: String {
+    switch self {
+    case .ascending:
+      return "proposalId"
+    case .descending:
+      return "-proposalId"
+    }
+  }
+}
+
 enum SERepositoryError: Error, LocalizedError, Equatable {
   case invalidBaseURL
   case httpStatus(Int)
@@ -31,14 +45,19 @@ enum SERepositoryError: Error, LocalizedError, Equatable {
 struct SERepository: Sendable {
   private static let pageSize = 10
 
-  func fetch(page: Int, searchText: String? = nil) async throws -> PayloadListResponse<PayloadProposal> {
+  func fetch(
+    page: Int,
+    searchText: String? = nil,
+    sortOrder: ProposalSortOrder = .ascending
+  ) async throws -> PayloadListResponse<PayloadProposal> {
     let baseURL = Env.serverBaseURL
     let apiKey = Env.serverApiKey
     let requestURL = try Self.proposalsURL(
       baseURL: baseURL,
       page: page,
       limit: Self.pageSize,
-      searchText: searchText
+      searchText: searchText,
+      sortOrder: sortOrder
     )
     var request = URLRequest(url: requestURL)
     request.httpMethod = "GET"
@@ -66,7 +85,8 @@ struct SERepository: Sendable {
     baseURL: String,
     page: Int,
     limit: Int,
-    searchText: String? = nil
+    searchText: String? = nil,
+    sortOrder: ProposalSortOrder = .ascending
   ) throws -> URL {
     var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     while trimmed.hasSuffix("/") {
@@ -78,7 +98,7 @@ struct SERepository: Sendable {
     var items: [URLQueryItem] = [
       URLQueryItem(name: "page", value: String(page)),
       URLQueryItem(name: "limit", value: String(limit)),
-      URLQueryItem(name: "sort", value: "proposalId"),
+      URLQueryItem(name: "sort", value: sortOrder.queryValue),
     ]
     let trimmedSearch = (searchText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     if !trimmedSearch.isEmpty {

--- a/ios/se-masked-quizTests/SERepositoryTests.swift
+++ b/ios/se-masked-quizTests/SERepositoryTests.swift
@@ -90,6 +90,30 @@ struct SERepositoryTests {
     #expect(!query.contains("where"))
   }
 
+  @Test("sortOrder=ascending のとき sort=proposalId が指定される")
+  func proposalsURLAscendingSort() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      sortOrder: .ascending
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "sort", value: "proposalId")))
+  }
+
+  @Test("sortOrder=descending のとき sort=-proposalId が指定される")
+  func proposalsURLDescendingSort() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      sortOrder: .descending
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "sort", value: "-proposalId")))
+  }
+
   @Test("searchText指定時は title/proposalId/authors への contains クエリが含まれる")
   func proposalsURLWithSearchText() throws {
     let url = try SERepository.proposalsURL(

--- a/ios/se-masked-quizTests/SERepositoryTests.swift
+++ b/ios/se-masked-quizTests/SERepositoryTests.swift
@@ -76,7 +76,7 @@ struct SERepositoryTests {
     #expect(se.status == "Accepted")
   }
 
-  @Test("searchText未指定時は where 系クエリを含まない")
+  @Test("searchText未指定時は where 系クエリを含まず、デフォルトで降順ソートになる")
   func proposalsURLWithoutSearchText() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com/",
@@ -86,7 +86,7 @@ struct SERepositoryTests {
     let query = url.query ?? ""
     #expect(query.contains("page=1"))
     #expect(query.contains("limit=10"))
-    #expect(query.contains("sort=proposalId"))
+    #expect(query.contains("sort=-proposalId"))
     #expect(!query.contains("where"))
   }
 


### PR DESCRIPTION
- SERepository に ProposalSortOrder を追加し sort クエリを切り替え可能に
- ProposalListScreen のツールバーに並び順メニューを追加
- 並び順変更時は1ページ目から再フェッチ