### PR TITLE
fix(server): ビルド時の PAYLOAD_SECRET 必須チェックを実行時のみに限定

### DIFF
--- a/server/src/payload.config.ts
+++ b/server/src/payload.config.ts
@@ -58,12 +58,17 @@ const cloudflare =
     ? await getCloudflareContextFromWrangler()
     : await getCloudflareContext({ async: true })
 
-if (!process.env.PAYLOAD_SECRET) {
+// Cloudflare Workers Builds does not expose runtime secrets during `next build`,
+// so the secret is only enforced at runtime. The placeholder is never used in
+// production: at runtime the real secret is required or startup fails below.
+const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build'
+
+if (!isBuildPhase && !process.env.PAYLOAD_SECRET) {
   throw new Error('PAYLOAD_SECRET environment variable is required')
 }
 
 export default buildConfig({
-  secret: process.env.PAYLOAD_SECRET,
+  secret: process.env.PAYLOAD_SECRET || 'build-time-placeholder-never-used-at-runtime',
   db: sqliteD1Adapter({
     binding: cloudflare.env.DB,
   }),


### PR DESCRIPTION
## 背景・目的

PR #35 で追加した `PAYLOAD_SECRET` 必須チェックが、モジュール読み込み時（= `next build` 時）にも実行されるため、Cloudflare Workers Builds のデプロイビルドが失敗していた。

Cloudflare Workers Builds は `wrangler secret put` で設定した secret を **ビルド工程では注入しない**（実行時専用）ため、CI のビルド中は `process.env.PAYLOAD_SECRET` が未定義となり、以下で失敗していた。

```
Error: PAYLOAD_SECRET environment variable is required
[Error: Failed to collect page data for /api/[...slug]]
```

## 変更点

`server/src/payload.config.ts`:

- `next build` 中（`NEXT_PHASE === 'phase-production-build'`）は必須チェックの throw をスキップ
- secret 未設定時のビルド用プレースホルダを設定

セキュリティ意図は維持。**本番の実行時**は `NEXT_PHASE` がビルドフェーズではないため、`PAYLOAD_SECRET` 未設定なら従来どおり起動時に throw する（プレースホルダが本番で使われることはない）。

## 検証

- ✅ secret 無しで `next build` 実行 → 修正前は `PAYLOAD_SECRET ... required` で失敗、修正後はチェックを通過（throw が消えることを確認）
- ✅ `wrangler deploy --dry-run` で `ratelimits` 含む全バインディングが妥当
- 実行時 secret（`PAYLOAD_SECRET` / `ADMIN_GATE_USER` / `ADMIN_GATE_PASSWORD`）は設定済みを確認済み

## レビューポイント

- `NEXT_PHASE` によるビルド/実行時の判定が意図通りか
- プレースホルダ値が実行時に使用されない（必ず実 secret か throw になる）こと

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->