### PR TITLE
feat(ios): リテンション向上の習慣ループ（デイリーチャレンジ/ストリーク/通知/計測）を追加

### DIFF
--- a/ios/se-masked-quiz/PrivacyInfo.xcprivacy
+++ b/ios/se-masked-quiz/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ios/se-masked-quiz/ProposalFeature/DailyChallengeCard.swift
+++ b/ios/se-masked-quiz/ProposalFeature/DailyChallengeCard.swift
@@ -1,0 +1,77 @@
+//
+//  DailyChallengeCard.swift
+//  se-masked-quiz
+//
+//  ホーム（提案一覧）の先頭に表示する「今日のチャレンジ」カード。
+//  習慣ループの起点：ストリーク（投資）の可視化と、今日解くべき提案（行動）への導線。
+//
+
+import SwiftUI
+
+struct DailyChallengeCard: View {
+  @Environment(\.streakRepository) private var streakRepository
+
+  let proposal: SwiftEvolution
+
+  @State private var streak: StreakRecord = .empty
+
+  private var isDoneToday: Bool {
+    streak.isActive(on: Date())
+  }
+
+  var body: some View {
+    HStack(spacing: 14) {
+      streakBadge
+
+      VStack(alignment: .leading, spacing: 4) {
+        Text("今日のチャレンジ")
+          .font(.caption.weight(.semibold))
+          .foregroundStyle(.secondary)
+
+        MarkdownText(proposal.title)
+          .font(.headline)
+          .lineLimit(2)
+
+        Text("SE-\(proposal.proposalId)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+
+        if isDoneToday {
+          Label("今日は達成済み", systemImage: "checkmark.circle.fill")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.green)
+        } else {
+          Label("タップして挑戦", systemImage: "play.circle.fill")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.tint)
+        }
+      }
+
+      Spacer(minLength: 0)
+    }
+    .padding(.vertical, 6)
+    .task(id: proposal.id) {
+      streak = await streakRepository.getStreak()
+    }
+    .onAppear {
+      Task { streak = await streakRepository.getStreak() }
+    }
+  }
+
+  private var streakBadge: some View {
+    VStack(spacing: 2) {
+      Image(systemName: "flame.fill")
+        .font(.title2)
+        .foregroundStyle(streak.currentStreak > 0 ? .orange : .secondary)
+      Text("\(streak.currentStreak)")
+        .font(.title3.weight(.bold))
+        .monospacedDigit()
+      Text("日連続")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+    .frame(width: 56)
+    .accessibilityElement(children: .combine)
+    .accessibilityLabel("連続学習\(streak.currentStreak)日")
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -10,7 +10,10 @@ import SwiftUI
 struct ProposalListScreen: View {
   @Environment(\.seRepository) var repository
   @Environment(\.quizRepository) var quizRepository
+  @Environment(\.streakRepository) var streakRepository
+  @Environment(\.analytics) var analytics
   @State private var proposals: AsyncProposals = .idle
+  @State private var dailyProposal: SwiftEvolution?
   @State private var modalWebUrl: URL?
   @State private var currentPage: Int = 1
   @State private var hasNextPage: Bool = true
@@ -81,6 +84,9 @@ struct ProposalListScreen: View {
 
           // 進捗情報を読み込む
           await loadQuizProgresses()
+
+          // 今日のチャレンジを読み込む
+          await loadDailyChallenge()
         } catch {
           self.proposals = .error(error)
         }
@@ -132,6 +138,13 @@ struct ProposalListScreen: View {
   @ViewBuilder
   private var proposalsList: some View {
     List {
+      if let daily = dailyProposal {
+        Section {
+          NavigationLink(value: daily) {
+            DailyChallengeCard(proposal: daily)
+          }
+        }
+      }
       ForEach(proposals.content) { proposal in
         NavigationLink(value: proposal) {
           VStack(alignment: .leading, spacing: 8) {
@@ -175,7 +188,9 @@ struct ProposalListScreen: View {
     .navigationDestination(for: SwiftEvolution.self) { proposal in
       ProposalQuizView(
         proposal: proposal,
-        quizRepository: quizRepository
+        quizRepository: quizRepository,
+        streakRepository: streakRepository,
+        analytics: analytics
       )
     }
     .toolbar {
@@ -271,6 +286,23 @@ struct ProposalListScreen: View {
     } catch {
       print("Failed to load quiz progresses:", error)
       // エラー時も進捗なしで表示を継続
+    }
+  }
+
+  /// 今日のチャレンジ対象の提案を決定論的に選び、内容を読み込む
+  private func loadDailyChallenge() async {
+    do {
+      let counts = try await quizRepository.getAllQuizCounts()
+      let service = DailyChallengeService()
+      guard
+        let proposalId = service.todaysProposalId(from: Array(counts.keys), date: Date())
+      else {
+        return
+      }
+      dailyProposal = try await repository.fetchProposal(byProposalId: proposalId)
+    } catch {
+      print("Failed to load daily challenge:", error)
+      // 失敗時はカードを出さずに一覧のみ表示を継続
     }
   }
 }

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -23,13 +23,17 @@ struct ProposalQuizView: View {
 
   init(
     proposal: SwiftEvolution,
-    quizRepository: any QuizRepository
+    quizRepository: any QuizRepository,
+    streakRepository: any StreakRepository = StreakRepositoryImpl(),
+    analytics: any AnalyticsService = ConsoleAnalyticsService()
   ) {
     self.proposal = proposal
     _quizViewModel = StateObject(
       wrappedValue: QuizViewModel(
         proposalId: proposal.proposalId,
-        quizRepository: quizRepository
+        quizRepository: quizRepository,
+        streakRepository: streakRepository,
+        analytics: analytics
       )
     )
   }

--- a/ios/se-masked-quiz/ProposalFeature/QuizViewModel.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizViewModel.swift
@@ -27,13 +27,19 @@ final class QuizViewModel: ObservableObject {
   @Published var hasLLMQuizzes: Bool = false
 
   private let quizRepository: any QuizRepository
+  private let streakRepository: any StreakRepository
+  private let analytics: any AnalyticsService
   private let proposalId: String
 
   init(
     proposalId: String,
-    quizRepository: any QuizRepository
+    quizRepository: any QuizRepository,
+    streakRepository: any StreakRepository = StreakRepositoryImpl(),
+    analytics: any AnalyticsService = ConsoleAnalyticsService()
   ) {
     self.quizRepository = quizRepository
+    self.streakRepository = streakRepository
+    self.analytics = analytics
     self.proposalId = proposalId
   }
 
@@ -138,6 +144,7 @@ final class QuizViewModel: ObservableObject {
       }
 
       isConfigured = true
+      analytics.track(.quizStarted(proposalId: proposalId))
     } catch {
       print("Failed to fetch quiz:", error)
     }
@@ -156,6 +163,7 @@ final class QuizViewModel: ObservableObject {
       let correct = answer == currentQuiz.answer
       isCorrect[index] = correct
       updateScore()
+      recordActivityAndTrack(isCorrect: correct)
     }
   }
 
@@ -219,6 +227,20 @@ final class QuizViewModel: ObservableObject {
     let correct = answer == quiz.correctAnswer
     isLLMCorrect[quiz.id] = correct
     updateLLMQuizScore()
+    recordActivityAndTrack(isCorrect: correct)
+  }
+
+  // MARK: - Streak & Analytics
+
+  /// 回答のたびにストリークを記録し、計測イベントを送る（習慣ループの「行動→投資」）
+  private func recordActivityAndTrack(isCorrect: Bool) {
+    analytics.track(.quizAnswered(isCorrect: isCorrect))
+    Task { [streakRepository, analytics] in
+      let result = await streakRepository.recordActivity(on: Date())
+      if result.isFirstActivityToday {
+        analytics.track(.streakIncremented(days: result.record.currentStreak))
+      }
+    }
   }
 
   /// LLMクイズを閉じる

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -81,6 +81,39 @@ struct SERepository: Sendable {
     }
   }
 
+  /// 提案IDを指定して単一の提案を取得する（デイリーチャレンジ用）
+  func fetchProposal(byProposalId proposalId: String) async throws -> SwiftEvolution? {
+    let baseURL = Env.serverBaseURL
+    let apiKey = Env.serverApiKey
+    var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    while trimmed.hasSuffix("/") {
+      trimmed.removeLast()
+    }
+    guard var components = URLComponents(string: "\(trimmed)/api/proposals") else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    components.queryItems = [
+      URLQueryItem(name: "where[proposalId][equals]", value: proposalId),
+      URLQueryItem(name: "limit", value: "1"),
+    ]
+    guard let url = components.url else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("users API-Key \(apiKey)", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw SERepositoryError.httpStatus(-1)
+    }
+    guard (200 ... 299).contains(http.statusCode) else {
+      throw SERepositoryError.httpStatus(http.statusCode)
+    }
+    let decoded = try JSONDecoder().decode(PayloadListResponse<PayloadProposal>.self, from: data)
+    return decoded.docs.first?.toSwiftEvolution()
+  }
+
   static func proposalsURL(
     baseURL: String,
     page: Int,

--- a/ios/se-masked-quiz/Repositories/StreakRepository.swift
+++ b/ios/se-masked-quiz/Repositories/StreakRepository.swift
@@ -1,0 +1,147 @@
+//
+//  StreakRepository.swift
+//  se-masked-quiz
+//
+//  連続学習日数（ストリーク）の記録・判定を担うリポジトリ。
+//  習慣ループの「投資」要素を担い、ローカル（UserDefaults）で完結する。
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Models
+
+/// 連続学習日数（ストリーク）の状態
+struct StreakRecord: Codable, Equatable, Sendable {
+  var currentStreak: Int
+  var longestStreak: Int
+  /// 最後に学習した日（その日の startOfDay）
+  var lastActiveDay: Date?
+  var totalActiveDays: Int
+
+  static let empty = StreakRecord(
+    currentStreak: 0, longestStreak: 0, lastActiveDay: nil, totalActiveDays: 0)
+
+  /// 指定日に学習済みか
+  func isActive(on date: Date, calendar: Calendar = .current) -> Bool {
+    guard let last = lastActiveDay else { return false }
+    return calendar.isDate(last, inSameDayAs: date)
+  }
+
+  /// ストリークが途切れ間近か（昨日まで継続中だが、今日はまだ未学習）
+  func isAtRisk(on date: Date, calendar: Calendar = .current) -> Bool {
+    guard currentStreak > 0, let last = lastActiveDay else { return false }
+    let today = calendar.startOfDay(for: date)
+    guard let yesterday = calendar.date(byAdding: .day, value: -1, to: today) else { return false }
+    return calendar.isDate(last, inSameDayAs: yesterday)
+  }
+}
+
+/// `recordActivity(on:)` の結果
+struct StreakUpdateResult: Sendable {
+  let record: StreakRecord
+  /// 前日からの連続でストリークが伸びた
+  let didIncrement: Bool
+  /// 今日はじめての学習だった（同日2回目以降は false）
+  let isFirstActivityToday: Bool
+}
+
+// MARK: - Repository Protocol
+
+/// @mockable
+protocol StreakRepository: Actor, Sendable {
+  /// 指定日の学習を記録し、更新後の状態を返す
+  func recordActivity(on date: Date) async -> StreakUpdateResult
+
+  /// 現在のストリーク状態を取得
+  func getStreak() async -> StreakRecord
+
+  /// ストリークをリセット（デバッグ・テスト用）
+  func reset() async
+}
+
+// MARK: - Repository Implementation
+
+actor StreakRepositoryImpl: StreakRepository {
+  private let userDefaults: UserDefaults
+  private let calendar: Calendar
+
+  private static let streakKey = "streak_record"
+
+  init(userDefaults: UserDefaults = .standard, calendar: Calendar = .current) {
+    self.userDefaults = userDefaults
+    self.calendar = calendar
+  }
+
+  func recordActivity(on date: Date) async -> StreakUpdateResult {
+    var record = loadRecord()
+    let today = calendar.startOfDay(for: date)
+
+    // すでに今日記録済みなら状態を変えない（同日の複数回回答に耐える）
+    if let last = record.lastActiveDay, calendar.isDate(last, inSameDayAs: today) {
+      return StreakUpdateResult(record: record, didIncrement: false, isFirstActivityToday: false)
+    }
+
+    var didIncrement = false
+    if let last = record.lastActiveDay {
+      let lastDay = calendar.startOfDay(for: last)
+      let dayGap = calendar.dateComponents([.day], from: lastDay, to: today).day ?? 0
+      if dayGap == 1 {
+        record.currentStreak += 1
+        didIncrement = true
+      } else {
+        // 1日以上空いた → ストリークは途切れて今日から再スタート
+        record.currentStreak = 1
+      }
+    } else {
+      record.currentStreak = 1
+    }
+
+    record.lastActiveDay = today
+    record.totalActiveDays += 1
+    record.longestStreak = max(record.longestStreak, record.currentStreak)
+    saveRecord(record)
+
+    return StreakUpdateResult(record: record, didIncrement: didIncrement, isFirstActivityToday: true)
+  }
+
+  func getStreak() async -> StreakRecord {
+    loadRecord()
+  }
+
+  func reset() async {
+    userDefaults.removeObject(forKey: Self.streakKey)
+  }
+
+  // MARK: - Private Helpers
+
+  private func loadRecord() -> StreakRecord {
+    guard let data = userDefaults.data(forKey: Self.streakKey),
+      let record = try? JSONDecoder().decode(StreakRecord.self, from: data)
+    else {
+      return .empty
+    }
+    return record
+  }
+
+  private func saveRecord(_ record: StreakRecord) {
+    if let encoded = try? JSONEncoder().encode(record) {
+      userDefaults.set(encoded, forKey: Self.streakKey)
+    }
+  }
+}
+
+// MARK: - Environment
+
+extension StreakRepositoryImpl: EnvironmentKey {
+  static var defaultValue: any StreakRepository {
+    StreakRepositoryImpl()
+  }
+}
+
+extension EnvironmentValues {
+  var streakRepository: any StreakRepository {
+    get { self[StreakRepositoryImpl.self] }
+    set { self[StreakRepositoryImpl.self] = newValue }
+  }
+}

--- a/ios/se-masked-quiz/Services/AnalyticsService.swift
+++ b/ios/se-masked-quiz/Services/AnalyticsService.swift
@@ -1,0 +1,115 @@
+//
+//  AnalyticsService.swift
+//  se-masked-quiz
+//
+//  リテンション施策の効果測定に使う軽量・プライバシー配慮型の計測レイヤー。
+//  Phase 1 は os.Logger に出力する実装。将来 TelemetryDeck 等の SDK を導入する際は
+//  `AnalyticsService` を実装した別 struct を作り、合成点（App / EnvironmentKey）で差し替えるだけでよい。
+//
+
+import Foundation
+import OSLog
+import SwiftUI
+
+// MARK: - Events
+
+/// 計測イベント（最小セット）。ここから D1/D7/D30・デイリー完了率・
+/// ストリーク分布・通知許諾率・通知経由起動率を算出する。
+enum AnalyticsEvent: Sendable {
+  case appOpen
+  case quizStarted(proposalId: String)
+  case quizAnswered(isCorrect: Bool)
+  case dailyChallengeCompleted(streak: Int)
+  case streakIncremented(days: Int)
+  case notificationPermission(granted: Bool)
+  case notificationOpened
+  case reminderTimeSet(hour: Int, minute: Int)
+
+  var name: String {
+    switch self {
+    case .appOpen: return "app_open"
+    case .quizStarted: return "quiz_started"
+    case .quizAnswered: return "quiz_answered"
+    case .dailyChallengeCompleted: return "daily_challenge_completed"
+    case .streakIncremented: return "streak_incremented"
+    case .notificationPermission: return "notification_permission"
+    case .notificationOpened: return "notification_opened"
+    case .reminderTimeSet: return "reminder_time_set"
+    }
+  }
+
+  /// 個人を特定しない最小限のパラメータのみを持たせる
+  var parameters: [String: String] {
+    switch self {
+    case .appOpen, .notificationOpened:
+      return [:]
+    case .quizStarted(let proposalId):
+      return ["proposalId": proposalId]
+    case .quizAnswered(let isCorrect):
+      return ["isCorrect": String(isCorrect)]
+    case .dailyChallengeCompleted(let streak):
+      return ["streak": String(streak)]
+    case .streakIncremented(let days):
+      return ["days": String(days)]
+    case .notificationPermission(let granted):
+      return ["granted": String(granted)]
+    case .reminderTimeSet(let hour, let minute):
+      return ["hour": String(hour), "minute": String(minute)]
+    }
+  }
+}
+
+// MARK: - Opt-out
+
+/// 計測のオプトアウト設定（設定画面と共有）
+enum AnalyticsSettings {
+  static let optOutKey = "analytics_opt_out"
+
+  static var isOptedOut: Bool {
+    UserDefaults.standard.bool(forKey: optOutKey)
+  }
+}
+
+// MARK: - Service Protocol
+
+protocol AnalyticsService: Sendable {
+  func track(_ event: AnalyticsEvent)
+}
+
+// MARK: - Console Implementation (Phase 1)
+
+/// os.Logger に出力するだけの実装。端末外へは一切送信しないためプライバシー上安全。
+struct ConsoleAnalyticsService: AnalyticsService {
+  private let logger = Logger(subsystem: "dev.fummicc1.se-masked-quiz", category: "analytics")
+
+  func track(_ event: AnalyticsEvent) {
+    guard !AnalyticsSettings.isOptedOut else { return }
+
+    let params = event.parameters
+    if params.isEmpty {
+      logger.log("📊 \(event.name, privacy: .public)")
+    } else {
+      let joined =
+        params
+        .map { "\($0.key)=\($0.value)" }
+        .sorted()
+        .joined(separator: " ")
+      logger.log("📊 \(event.name, privacy: .public) \(joined, privacy: .public)")
+    }
+  }
+}
+
+// MARK: - Environment
+
+extension ConsoleAnalyticsService: EnvironmentKey {
+  static var defaultValue: any AnalyticsService {
+    ConsoleAnalyticsService()
+  }
+}
+
+extension EnvironmentValues {
+  var analytics: any AnalyticsService {
+    get { self[ConsoleAnalyticsService.self] }
+    set { self[ConsoleAnalyticsService.self] = newValue }
+  }
+}

--- a/ios/se-masked-quiz/Services/DailyChallengeService.swift
+++ b/ios/se-masked-quiz/Services/DailyChallengeService.swift
@@ -1,0 +1,39 @@
+//
+//  DailyChallengeService.swift
+//  se-masked-quiz
+//
+//  「今日のチャレンジ」となる提案を、日付から決定論的に選ぶ純粋ロジック。
+//  サーバ不要・オフライン可・テスト容易（同じ日付なら必ず同じ結果）。
+//
+
+import Foundation
+
+struct DailyChallengeService: Sendable {
+  /// ローテーションの基準日（エポック）
+  static let referenceDate = Date(timeIntervalSince1970: 0)
+
+  /// クイズを持つ提案IDの一覧から、その日のチャレンジ対象を返す。
+  /// クイズが存在する提案のみを対象にするため、必ず出題可能な提案が選ばれる。
+  /// - Parameters:
+  ///   - quizzedProposalIds: クイズ（穴埋め）が存在する提案IDの集合
+  ///   - date: 対象日
+  func todaysProposalId(
+    from quizzedProposalIds: [String],
+    date: Date,
+    calendar: Calendar = .current
+  ) -> String? {
+    let sorted = quizzedProposalIds.sorted()
+    guard !sorted.isEmpty else { return nil }
+    let dayIndex = dayNumber(for: date, calendar: calendar)
+    // 負の経過日数でも正のインデックスになるよう補正
+    let index = ((dayIndex % sorted.count) + sorted.count) % sorted.count
+    return sorted[index]
+  }
+
+  /// 基準日からの経過日数
+  func dayNumber(for date: Date, calendar: Calendar = .current) -> Int {
+    let start = calendar.startOfDay(for: Self.referenceDate)
+    let day = calendar.startOfDay(for: date)
+    return calendar.dateComponents([.day], from: start, to: day).day ?? 0
+  }
+}

--- a/ios/se-masked-quiz/Services/NotificationService.swift
+++ b/ios/se-masked-quiz/Services/NotificationService.swift
@@ -1,0 +1,91 @@
+//
+//  NotificationService.swift
+//  se-masked-quiz
+//
+//  習慣ループの「トリガー」を担うローカル通知（学習リマインダー）の管理。
+//  サーバ・APNs 不要。毎日指定時刻に繰り返す UNCalendarNotificationTrigger を使う。
+//
+
+import Foundation
+import UserNotifications
+
+// MARK: - Preferences
+
+/// 学習リマインダーの設定（UserDefaults キーと既定値）
+enum ReminderPreferences {
+  static let enabledKey = "reminder_enabled"
+  static let hourKey = "reminder_hour"
+  static let minuteKey = "reminder_minute"
+
+  static let defaultHour = 20
+  static let defaultMinute = 0
+
+  static var isEnabled: Bool {
+    UserDefaults.standard.bool(forKey: enabledKey)
+  }
+
+  static var hour: Int {
+    UserDefaults.standard.object(forKey: hourKey) == nil
+      ? defaultHour : UserDefaults.standard.integer(forKey: hourKey)
+  }
+
+  static var minute: Int {
+    UserDefaults.standard.object(forKey: minuteKey) == nil
+      ? defaultMinute : UserDefaults.standard.integer(forKey: minuteKey)
+  }
+}
+
+// MARK: - Service
+
+struct NotificationService: Sendable {
+  static let dailyReminderIdentifier = "daily_study_reminder"
+
+  /// 通知の許諾を要求し、許可されたかを返す
+  func requestAuthorization() async -> Bool {
+    do {
+      return try await UNUserNotificationCenter.current()
+        .requestAuthorization(options: [.alert, .sound, .badge])
+    } catch {
+      return false
+    }
+  }
+
+  /// 現在の許諾状態
+  func authorizationStatus() async -> UNAuthorizationStatus {
+    await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+  }
+
+  /// 毎日指定時刻のリマインダーを登録（既存があれば置き換え）。
+  /// 本文には現在のストリーク日数を埋め込み、継続意欲（loss aversion）を刺激する。
+  func scheduleDailyReminder(hour: Int, minute: Int, currentStreak: Int) async {
+    let center = UNUserNotificationCenter.current()
+    center.removePendingNotificationRequests(withIdentifiers: [Self.dailyReminderIdentifier])
+
+    let content = UNMutableNotificationContent()
+    content.title = "今日のクイズに挑戦しよう 🧩"
+    if currentStreak > 0 {
+      content.body = "ストリーク \(currentStreak)日継続中。今日も解いて記録を伸ばそう！"
+    } else {
+      content.body = "1日1問でも続ければ力になります。今日のチャレンジを始めましょう。"
+    }
+    content.sound = .default
+
+    var components = DateComponents()
+    components.hour = hour
+    components.minute = minute
+    let trigger = UNCalendarNotificationTrigger(dateMatching: components, repeats: true)
+
+    let request = UNNotificationRequest(
+      identifier: Self.dailyReminderIdentifier,
+      content: content,
+      trigger: trigger
+    )
+    try? await center.add(request)
+  }
+
+  /// リマインダーを解除
+  func cancelDailyReminder() {
+    UNUserNotificationCenter.current()
+      .removePendingNotificationRequests(withIdentifiers: [Self.dailyReminderIdentifier])
+  }
+}

--- a/ios/se-masked-quiz/SettingFeature/SettingScreen.swift
+++ b/ios/se-masked-quiz/SettingFeature/SettingScreen.swift
@@ -8,9 +8,50 @@
 import SwiftUI
 
 struct SettingScreen: View {
+  @Environment(\.streakRepository) private var streakRepository
+  @Environment(\.analytics) private var analytics
+
+  @AppStorage(ReminderPreferences.enabledKey) private var reminderEnabled = false
+  @AppStorage(ReminderPreferences.hourKey) private var reminderHour = ReminderPreferences.defaultHour
+  @AppStorage(ReminderPreferences.minuteKey) private var reminderMinute = ReminderPreferences
+    .defaultMinute
+  @AppStorage(AnalyticsSettings.optOutKey) private var analyticsOptOut = false
+
+  private var reminderTime: Binding<Date> {
+    Binding(
+      get: {
+        Calendar.current.date(
+          from: DateComponents(hour: reminderHour, minute: reminderMinute)) ?? Date()
+      },
+      set: { newDate in
+        let comps = Calendar.current.dateComponents([.hour, .minute], from: newDate)
+        reminderHour = comps.hour ?? ReminderPreferences.defaultHour
+        reminderMinute = comps.minute ?? ReminderPreferences.defaultMinute
+      }
+    )
+  }
+
   var body: some View {
     NavigationStack {
       List {
+        // 学習リマインダー Section
+        Section {
+          Toggle(isOn: $reminderEnabled) {
+            Label("毎日のリマインダー", systemImage: "bell.badge")
+          }
+          if reminderEnabled {
+            DatePicker(
+              "通知時刻",
+              selection: reminderTime,
+              displayedComponents: .hourAndMinute
+            )
+          }
+        } header: {
+          Text("学習リマインダー")
+        } footer: {
+          Text("毎日決まった時刻に「今日のクイズ」をお知らせします。続けるほどストリークが伸びます。")
+        }
+
         // LLM Model Section (Issue #12)
         Section("LLMモデル") {
           NavigationLink {
@@ -22,6 +63,22 @@ struct SettingScreen: View {
               Text("モデル管理")
             }
           }
+        }
+
+        // プライバシー Section
+        Section {
+          Toggle(
+            isOn: Binding(
+              get: { !analyticsOptOut },
+              set: { analyticsOptOut = !$0 }
+            )
+          ) {
+            Label("利用状況の計測を許可", systemImage: "chart.bar")
+          }
+        } header: {
+          Text("プライバシー")
+        } footer: {
+          Text("アプリの改善のため、匿名の利用状況のみを記録します。端末外の第三者には送信しません。")
         }
 
         // License Section
@@ -47,6 +104,49 @@ struct SettingScreen: View {
         }
       }
       .navigationTitle("設定")
+    }
+    .onChange(of: reminderEnabled) { _, enabled in
+      applyReminderEnabled(enabled)
+    }
+    .onChange(of: reminderHour) { _, _ in
+      rescheduleReminderIfEnabled()
+    }
+    .onChange(of: reminderMinute) { _, _ in
+      rescheduleReminderIfEnabled()
+    }
+  }
+
+  // MARK: - Reminder Scheduling
+
+  private func applyReminderEnabled(_ enabled: Bool) {
+    let service = NotificationService()
+    if enabled {
+      Task { @MainActor in
+        let granted = await service.requestAuthorization()
+        analytics.track(.notificationPermission(granted: granted))
+        if granted {
+          let streak = await streakRepository.getStreak()
+          await service.scheduleDailyReminder(
+            hour: reminderHour, minute: reminderMinute, currentStreak: streak.currentStreak)
+          analytics.track(.reminderTimeSet(hour: reminderHour, minute: reminderMinute))
+        } else {
+          // 許可されなかった場合は UI を実態に合わせて戻す
+          reminderEnabled = false
+        }
+      }
+    } else {
+      service.cancelDailyReminder()
+    }
+  }
+
+  private func rescheduleReminderIfEnabled() {
+    guard reminderEnabled else { return }
+    let service = NotificationService()
+    Task { @MainActor in
+      let streak = await streakRepository.getStreak()
+      await service.scheduleDailyReminder(
+        hour: reminderHour, minute: reminderMinute, currentStreak: streak.currentStreak)
+      analytics.track(.reminderTimeSet(hour: reminderHour, minute: reminderMinute))
     }
   }
 }

--- a/ios/se-masked-quiz/se_masked_quizApp.swift
+++ b/ios/se-masked-quiz/se_masked_quizApp.swift
@@ -9,9 +9,36 @@ import SwiftUI
 
 @main
 struct se_masked_quizApp: App {
+  @Environment(\.scenePhase) private var scenePhase
+
+  private let analytics: any AnalyticsService = ConsoleAnalyticsService()
+  private let streakRepository: any StreakRepository = StreakRepositoryImpl()
+  private let notificationService = NotificationService()
+
   var body: some Scene {
     WindowGroup {
       ProposalListScreen()
+        .environment(\.analytics, analytics)
+        .environment(\.streakRepository, streakRepository)
+    }
+    .onChange(of: scenePhase) { _, newPhase in
+      guard newPhase == .active else { return }
+      handleBecameActive()
+    }
+  }
+
+  /// 起動・前面復帰時：起動計測と、リマインダー本文の最新ストリークへの更新
+  private func handleBecameActive() {
+    analytics.track(.appOpen)
+
+    guard ReminderPreferences.isEnabled else { return }
+    Task {
+      let streak = await streakRepository.getStreak()
+      await notificationService.scheduleDailyReminder(
+        hour: ReminderPreferences.hour,
+        minute: ReminderPreferences.minute,
+        currentStreak: streak.currentStreak
+      )
     }
   }
 }

--- a/ios/se-masked-quizTests/DailyChallengeServiceTests.swift
+++ b/ios/se-masked-quizTests/DailyChallengeServiceTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("DailyChallengeService Tests")
+struct DailyChallengeServiceTests {
+
+  // MARK: - Helpers
+
+  private var utcCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+  }
+
+  private func day(_ year: Int, _ month: Int, _ d: Int) -> Date {
+    utcCalendar.date(from: DateComponents(year: year, month: month, day: d, hour: 12))!
+  }
+
+  // MARK: - Tests
+
+  @Test("同じ日付なら必ず同じ提案が選ばれる")
+  func deterministic() {
+    let sut = DailyChallengeService()
+    let ids = ["0001", "0002", "0003", "0004", "0005"]
+    let first = sut.todaysProposalId(from: ids, date: day(2026, 1, 1), calendar: utcCalendar)
+    let second = sut.todaysProposalId(from: ids, date: day(2026, 1, 1), calendar: utcCalendar)
+    #expect(first != nil)
+    #expect(first == second)
+  }
+
+  @Test("空配列なら nil")
+  func emptyReturnsNil() {
+    let sut = DailyChallengeService()
+    #expect(sut.todaysProposalId(from: [], date: day(2026, 1, 1), calendar: utcCalendar) == nil)
+  }
+
+  @Test("連続する日で順番にローテーションし、件数を超えると先頭に戻る")
+  func rotation() {
+    let sut = DailyChallengeService()
+    let ids = ["0001", "0002", "0003"]
+    let d0 = sut.todaysProposalId(from: ids, date: day(2026, 1, 1), calendar: utcCalendar)
+    let d1 = sut.todaysProposalId(from: ids, date: day(2026, 1, 2), calendar: utcCalendar)
+    let d2 = sut.todaysProposalId(from: ids, date: day(2026, 1, 3), calendar: utcCalendar)
+    let d3 = sut.todaysProposalId(from: ids, date: day(2026, 1, 4), calendar: utcCalendar)
+    #expect(Set([d0, d1, d2]).count == 3)  // 3日とも別の提案
+    #expect(d3 == d0)  // 4日目は1日目に戻る
+  }
+
+  @Test("入力順に依存しない（内部でソートして選ぶ）")
+  func orderIndependent() {
+    let sut = DailyChallengeService()
+    let shuffled = sut.todaysProposalId(
+      from: ["0003", "0001", "0002"], date: day(2026, 1, 1), calendar: utcCalendar)
+    let sorted = sut.todaysProposalId(
+      from: ["0001", "0002", "0003"], date: day(2026, 1, 1), calendar: utcCalendar)
+    #expect(shuffled == sorted)
+  }
+}

--- a/ios/se-masked-quizTests/StreakRepositoryTests.swift
+++ b/ios/se-masked-quizTests/StreakRepositoryTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("StreakRepository Tests")
+struct StreakRepositoryTests {
+
+  // MARK: - Helpers
+
+  private var utcCalendar: Calendar {
+    var calendar = Calendar(identifier: .gregorian)
+    calendar.timeZone = TimeZone(identifier: "UTC")!
+    return calendar
+  }
+
+  private func makeSUT() -> StreakRepositoryImpl {
+    let suiteName = "streak-test-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return StreakRepositoryImpl(userDefaults: defaults, calendar: utcCalendar)
+  }
+
+  private func day(_ year: Int, _ month: Int, _ d: Int) -> Date {
+    utcCalendar.date(from: DateComponents(year: year, month: month, day: d, hour: 12))!
+  }
+
+  // MARK: - Tests
+
+  @Test("初回学習でストリークが1になる")
+  func firstActivity() async {
+    let sut = makeSUT()
+    let result = await sut.recordActivity(on: day(2026, 1, 1))
+    #expect(result.record.currentStreak == 1)
+    #expect(result.record.longestStreak == 1)
+    #expect(result.record.totalActiveDays == 1)
+    #expect(result.isFirstActivityToday == true)
+  }
+
+  @Test("同日に複数回回答してもストリークは増えない")
+  func sameDayNoOp() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    let second = await sut.recordActivity(on: day(2026, 1, 1))
+    #expect(second.record.currentStreak == 1)
+    #expect(second.record.totalActiveDays == 1)
+    #expect(second.didIncrement == false)
+    #expect(second.isFirstActivityToday == false)
+  }
+
+  @Test("連続した日でストリークが増える")
+  func consecutiveDays() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    _ = await sut.recordActivity(on: day(2026, 1, 2))
+    let third = await sut.recordActivity(on: day(2026, 1, 3))
+    #expect(third.record.currentStreak == 3)
+    #expect(third.record.longestStreak == 3)
+    #expect(third.record.totalActiveDays == 3)
+    #expect(third.didIncrement == true)
+  }
+
+  @Test("1日以上空くとストリークがリセットされ、最長は維持される")
+  func gapResetsButKeepsLongest() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    _ = await sut.recordActivity(on: day(2026, 1, 2))
+    let afterGap = await sut.recordActivity(on: day(2026, 1, 5))
+    #expect(afterGap.record.currentStreak == 1)
+    #expect(afterGap.record.longestStreak == 2)
+    #expect(afterGap.record.totalActiveDays == 3)
+    #expect(afterGap.didIncrement == false)
+  }
+
+  @Test("isActive / isAtRisk の判定")
+  func activeAndRisk() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    let record = await sut.getStreak()
+    let cal = utcCalendar
+
+    #expect(record.isActive(on: day(2026, 1, 1), calendar: cal) == true)
+    #expect(record.isActive(on: day(2026, 1, 2), calendar: cal) == false)
+    // 昨日まで継続・今日未学習 → リスク
+    #expect(record.isAtRisk(on: day(2026, 1, 2), calendar: cal) == true)
+    // 今日学習済み → リスクではない
+    #expect(record.isAtRisk(on: day(2026, 1, 1), calendar: cal) == false)
+    // 2日以上空いた → すでに途切れているのでリスク扱いしない
+    #expect(record.isAtRisk(on: day(2026, 1, 3), calendar: cal) == false)
+  }
+
+  @Test("reset で空に戻る")
+  func resetClears() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    await sut.reset()
+    let record = await sut.getStreak()
+    #expect(record == .empty)
+  }
+}


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## 背景・目的

学習アプリでありながら「毎日アプリを開く動機づけ（習慣化の仕組み）」がほぼ未実装で、効果計測の基盤も無かった。Nir Eyal の Hook モデル（トリガー→行動→報酬→投資）に沿った施策を **Phase 1** として導入し、毎日アプリを開く行動とリテンションを高める。

- **アカウント不要・サーバ変更なし**。既存アーキテクチャ（actor リポジトリ + UserDefaults + `EnvironmentKey` 注入）に整合。
- 習慣ループの対応: 通知=トリガー / デイリーチャレンジ=行動 / スコア・正誤=報酬 / ストリーク=投資。

## 主要な変更点

### 新規
| ファイル | 役割 |
|---|---|
| `Repositories/StreakRepository.swift` | 連続学習日数の記録・判定（actor + UserDefaults） |
| `Services/DailyChallengeService.swift` | 日付から決定論的に「今日の提案」を選ぶ純粋ロジック |
| `Services/NotificationService.swift` | 学習リマインダー（権限要求・日次ローカル通知） |
| `Services/AnalyticsService.swift` | 軽量・プライバシー配慮型の計測（protocol + os.Logger、オプトアウト対応） |
| `ProposalFeature/DailyChallengeCard.swift` | 一覧先頭に🔥連続日数＋今日のチャレンジ導線を表示 |
| `PrivacyInfo.xcprivacy` | UserDefaults 利用理由（CA92.1）を宣言 |

### 変更
- `QuizViewModel`: 回答時にストリーク記録と計測イベント（`quiz_answered` / `streak_incremented`）を発火。`init` で依存注入。
- `ProposalQuizView` / `ProposalListScreen`: 依存注入とデイリーチャレンジカードの統合。
- `SettingScreen`: 学習リマインダー設定（ON/OFF・時刻）と計測オプトアウトを追加。
- `se_masked_quizApp`: `scenePhase` で `app_open` 計測と、最新ストリークでの通知本文再スケジュール。
- `SERepository`: 提案IDによる単体取得 `fetchProposal(byProposalId:)` を追加。

## テストの実行状況

- ✅ **ビルド成功**（iOS Simulator, エラー 0）※秘密ファイル `Env.swift` が無い環境では `-D CI` で検証
- ✅ **swift-format lint: 問題なし**
- ✅ **TEST SUCCEEDED** — 新規10ケース（`StreakRepositoryTests` 6 / `DailyChallengeServiceTests` 4）＋既存テストすべて合格
- ✅ アプリ起動 OK（クラッシュなし）／実行時ログで `app_open` 計測の発火を確認

## レビューポイント

- **計測実装の方針**: プランでは TelemetryDeck を想定していたが、remote SPM パッケージ追加（`project.pbxproj` / `Package.resolved` の手編集）は壊れやすいため、`AnalyticsService` プロトコル + os.Logger 実装に。SDK 導入時は合成点（App / `EnvironmentKey`）の差し替えのみで対応可能。
- **ストリークの粒度**: 「その日に1問でも回答」で継続とする寛容な設計。
- **デイリーチャレンジの選択**: クイズを持つ提案IDをソートし `経過日数 % 件数` で決定論的に選択。タイムゾーン依存を避けるため `Calendar` を注入可能に。
- **プライバシー**: 現状は端末外送信なし（os.Logger のみ）。`PrivacyInfo.xcprivacy` は UserDefaults のみ宣言。

## ロードマップ（参考）

- Phase 2: ウィジェット / 復習キュー（間隔反復）/ バッジ・実績
- Phase 3（要バックエンド投資）: リーダーボード / クラウド同期 / サーバ駆動プッシュ

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf
