### PR TITLE
fix(server): proposalId 検証を bare 形式に緩和し status 上限を拡大

### DIFF
--- a/server/src/collections/Proposals.ts
+++ b/server/src/collections/Proposals.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-const PROPOSAL_ID_PATTERN = /^SE-\d{4}$/
+const PROPOSAL_ID_PATTERN = /^\d{4}$/
 
 export const Proposals: CollectionConfig = {
   slug: 'proposals',
@@ -22,7 +22,7 @@ export const Proposals: CollectionConfig = {
       index: true,
       validate: (value: unknown) => {
         if (typeof value !== 'string' || !PROPOSAL_ID_PATTERN.test(value)) {
-          return 'proposalId must match SE-NNNN (e.g. SE-0001)'
+          return 'proposalId must be four digits (e.g. 0001)'
         }
         return true
       },
@@ -53,7 +53,7 @@ export const Proposals: CollectionConfig = {
     {
       name: 'status',
       type: 'text',
-      maxLength: 100,
+      maxLength: 500,
     },
   ],
 }

--- a/server/src/collections/QuizAnswers.ts
+++ b/server/src/collections/QuizAnswers.ts
@@ -1,6 +1,6 @@
 import type { CollectionConfig } from 'payload'
 
-const PROPOSAL_ID_PATTERN = /^SE-\d{4}$/
+const PROPOSAL_ID_PATTERN = /^\d{4}$/
 const MAX_ANSWERS = 1000
 const MAX_OPTIONS_PER_ANSWER = 50
 const MAX_STRING_LENGTH = 2000
@@ -42,7 +42,7 @@ export const QuizAnswers: CollectionConfig = {
       index: true,
       validate: (value: unknown) => {
         if (typeof value !== 'string' || !PROPOSAL_ID_PATTERN.test(value)) {
-          return 'proposalId must match SE-NNNN (e.g. SE-0001)'
+          return 'proposalId must be four digits (e.g. 0001)'
         }
         return true
       },


### PR DESCRIPTION
## 概要
swift-evolution-masking の `mask-and-upload` ワークフローで、Payload CMS への **proposals / quiz-answers アップロードが全件 400 Bad Request で失敗**していた問題を修正します（CI はリトライ後 exit 0 で緑のままだが、実データが 1 件も登録できていなかった）。

## 根本原因
セキュリティ強化コミット `d0b15b0` で追加した `proposalId` の検証正規表現 `/^SE-\d{4}$/` が、システムの実際の形式と矛盾していた。

- アップローダー（`mask_and_upload.py`）はファイル名由来の **bare 形式 `0483`** を送信
- iOS アプリも bare 形式前提：表示時に `Text("SE-\(proposalId)")` で `SE-` を付与し、API は `where[proposalId][equals]=0483` で照合、テストも `proposalId == "0001"` を検証
- サーバーだけが `SE-0483` を要求していたため、全 proposal・全 quiz-answers が検証で弾かれていた（認証は API-Key で正常＝403 ではなく 400）

Payload の実レスポンス本文（CI ログ）で確定:
```
{"errors":[{"data":{"collection":"proposals","errors":[
  {"label":"Proposal Id","message":"proposalId must match SE-NNNN (e.g. SE-0001)","path":"proposalId"}]}}]}
```

`SE-` 送信に寄せるとアプリが二重 `SE-` 表示・クエリ不一致で壊れるため、**サーバー検証を bare 形式に合わせる**のが最小かつ整合的な修正。

## 変更内容
- `Proposals.ts` / `QuizAnswers.ts`: `PROPOSAL_ID_PATTERN` を `/^SE-\d{4}$/` → `/^\d{4}$/` に緩和し、エラーメッセージを更新
- `Proposals.ts`: `status` の `maxLength` を `100` → `500`（一部の SE は説明的な長い status を持ち 100 文字制限で弾かれていた。例: SE-0226 は 177 文字）

## DB / マイグレーション
DB は SQLite(D1) で `proposal_id` / `status` は length 制約のない `text` 列。`maxLength`・正規表現はアプリ層バリデーションのみで、**マイグレーション不要**。`validate` はリクエスト時評価のためデプロイ即反映。

## 検証
- 新正規表現の動作確認: `0001`/`0483`/`0226` 等の bare 4 桁を許可、`SE-0483`・不正値は拒否
- `tsc --noEmit`: 変更したコレクション 2 ファイルに型エラーなし
- マージ後にサーバーをデプロイ → "Update Masking Quiz" ワークフロー再実行で proposals/quiz-answers が登録されることを確認予定

## 残課題（本 PR 対象外・別リポジトリ）
- リネーム済みリダイレクトスタブ（例 SE-0519「This document was renamed...」）は title/authors を持たず必須検証で失敗するが、アップローダー側でスキップ可能（〜2 件、非コンテンツ）
- `mask_and_upload.py` の quiz-answers エラーハンドラが `response.text` を出さず診断を困難にしていた点の改善

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf