### PR TITLE
chore(server): 未使用の R2 バケット binding を削除

### DIFF
--- a/server/cloudflare-env.d.ts
+++ b/server/cloudflare-env.d.ts
@@ -1,6 +1,5 @@
 declare namespace Cloudflare {
   interface Env {
-    QUIZ_BUCKET: R2Bucket
     DB: D1Database
     ASSETS: Fetcher
     PAYLOAD_SECRET: string

--- a/server/worker-configuration.d.ts
+++ b/server/worker-configuration.d.ts
@@ -6,7 +6,6 @@ declare namespace Cloudflare {
 		mainModule: typeof import("./.open-next/worker");
 	}
 	interface Env {
-		QUIZ_BUCKET: R2Bucket;
 		DB: D1Database;
 		RL_API: RateLimit;
 		RL_ADMIN: RateLimit;

--- a/server/wrangler.jsonc
+++ b/server/wrangler.jsonc
@@ -32,17 +32,6 @@
   ],
 
   /**
-   * R2 Bucket Binding
-   * https://developers.cloudflare.com/r2/
-   */
-  "r2_buckets": [
-    {
-      "binding": "QUIZ_BUCKET",
-      "bucket_name": "se-masked-quiz"
-    }
-  ],
-
-  /**
    * Rate Limiting bindings (free with Workers plan).
    * https://developers.cloudflare.com/workers/runtime-apis/bindings/rate-limit/
    *


### PR DESCRIPTION
## 概要
クイズ/proposal データは Cloudflare D1 に永続化しており、R2 バケット binding `QUIZ_BUCKET` は**サーバーコードから一切参照されていない未使用 binding**です（`grep` で `env.QUIZ_BUCKET` の使用箇所ゼロを確認）。アップローダー（swift-evolution-masking）側の R2 二重保存廃止に合わせ、サーバー側の未使用 binding も削除します。

## 変更内容
- `wrangler.jsonc`: `r2_buckets`（`QUIZ_BUCKET` → `se-masked-quiz` バケット）定義を削除
- `cloudflare-env.d.ts` / `worker-configuration.d.ts`: `QUIZ_BUCKET: R2Bucket` 型定義を削除

## 検証
- `tsc --noEmit`: `QUIZ_BUCKET` 参照エラーなし（既存の vitest 未解決エラー以外は増えていない）
- `wrangler.jsonc` は JSONC として妥当・`r2_buckets` 除去を確認

## 関連
- アップローダー側の R2/microCMS 削除: fummicc1/swift-evolution-masking#8
- なお R2 バケット `se-masked-quiz` 自体や関連 Secrets は、両 PR マージ後に Cloudflare/GitHub 側で手動削除可能です

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf