### PR TITLE
Swift Evolution 依存グラフ機能（前提提案リスト＋グラフ画面）

### DIFF
--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphModels.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphModels.swift
@@ -1,0 +1,53 @@
+//
+//  DependencyGraphModels.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/27.
+//
+
+import Foundation
+
+/// グラフのノード（提案）。`hop` は root からの距離（0 = root）。
+struct GraphNode: Identifiable, Hashable {
+  let id: String  // proposalId
+  let title: String
+  let hop: Int
+}
+
+/// 有向エッジ（from が to を参照する）。
+struct GraphEdge: Hashable {
+  let from: String
+  let to: String
+}
+
+/// proposalId → 画面座標（中心を原点とした相対座標）。
+struct GraphLayout {
+  var positions: [String: CGPoint]
+}
+
+/// root を中心に置き、hop k のノードを半径 k·ringSpacing の同心円上へ等間隔配置する決定論レイアウト。
+enum RadialLayout {
+  static func compute(nodes: [GraphNode], center: CGPoint, ringSpacing: CGFloat) -> GraphLayout {
+    var positions: [String: CGPoint] = [:]
+    let byHop = Dictionary(grouping: nodes, by: \.hop)
+    for (hop, group) in byHop {
+      if hop == 0 {
+        if let root = group.first {
+          positions[root.id] = center
+        }
+        continue
+      }
+      let radius = CGFloat(hop) * ringSpacing
+      let sorted = group.sorted { $0.id < $1.id }
+      let count = max(sorted.count, 1)
+      for (index, node) in sorted.enumerated() {
+        let theta = (2 * CGFloat.pi / CGFloat(count)) * CGFloat(index) - CGFloat.pi / 2
+        positions[node.id] = CGPoint(
+          x: center.x + radius * cos(theta),
+          y: center.y + radius * sin(theta)
+        )
+      }
+    }
+    return GraphLayout(positions: positions)
+  }
+}

--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphRoute.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphRoute.swift
@@ -1,0 +1,14 @@
+//
+//  DependencyGraphRoute.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/27.
+//
+
+import Foundation
+
+/// 依存グラフ画面への遷移値。NavigationStack の value-based 遷移で使う。
+struct DependencyGraphRoute: Hashable {
+  let rootProposalId: String
+  let rootTitle: String
+}

--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphScreen.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphScreen.swift
@@ -1,0 +1,206 @@
+//
+//  DependencyGraphScreen.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/27.
+//
+
+import SwiftUI
+
+/// 選択した提案を中心に、依存（参照）関係の近傍をグラフ表示する画面。
+/// ノードをタップして「中心に」（再ルート）または「クイズを開く」を選べる。
+struct DependencyGraphScreen: View {
+  @Environment(\.seRepository) var seRepository
+  @StateObject private var viewModel = DependencyGraphViewModel()
+
+  let rootProposalId: String
+  let rootTitle: String
+
+  @State private var scale: CGFloat = 1
+  @State private var committedOffset: CGSize = .zero
+  @State private var dragOffset: CGSize = .zero
+  @State private var selectedNode: GraphNode?
+  @State private var selectedProposal: SwiftEvolution?
+
+  var body: some View {
+    GeometryReader { proxy in
+      let center = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
+      ZStack {
+        edgeCanvas(center: center)
+        nodeViews(center: center)
+      }
+      .scaleEffect(scale)
+      .offset(
+        x: committedOffset.width + dragOffset.width,
+        y: committedOffset.height + dragOffset.height
+      )
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .contentShape(Rectangle())
+      .gesture(
+        DragGesture()
+          .onChanged { dragOffset = $0.translation }
+          .onEnded { value in
+            committedOffset.width += value.translation.width
+            committedOffset.height += value.translation.height
+            dragOffset = .zero
+          }
+      )
+      .simultaneousGesture(
+        MagnificationGesture().onChanged { scale = min(max(0.5, $0), 2.5) }
+      )
+      .overlay(alignment: .top) { topBanner }
+      .overlay(alignment: .bottom) {
+        if let node = selectedNode {
+          selectionBar(node)
+        }
+      }
+    }
+    .navigationTitle("依存グラフ")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+    .task(id: selectedNode?.id) {
+      await loadSelectedProposal()
+    }
+    .task {
+      await viewModel.load(rootProposalId: rootProposalId, rootTitle: rootTitle)
+    }
+  }
+
+  // MARK: - Subviews
+
+  private func edgeCanvas(center: CGPoint) -> some View {
+    Canvas { context, _ in
+      for edge in viewModel.edges {
+        guard let from = viewModel.layout.positions[edge.from],
+          let to = viewModel.layout.positions[edge.to]
+        else { continue }
+        var path = Path()
+        path.move(to: screenPoint(from, center: center))
+        path.addLine(to: screenPoint(to, center: center))
+        context.stroke(path, with: .color(.secondary.opacity(0.4)), lineWidth: 1)
+      }
+    }
+  }
+
+  private func nodeViews(center: CGPoint) -> some View {
+    ForEach(viewModel.nodes) { node in
+      if let position = viewModel.layout.positions[node.id] {
+        NodeChipView(
+          node: node,
+          isRoot: node.hop == 0,
+          isSelected: selectedNode?.id == node.id
+        )
+        .position(screenPoint(position, center: center))
+        .onTapGesture { selectedNode = node }
+      }
+    }
+  }
+
+  @ViewBuilder
+  private var topBanner: some View {
+    if viewModel.isLoading {
+      ProgressView()
+        .padding(8)
+        .background(.ultraThinMaterial, in: Capsule())
+        .padding(.top, 8)
+    } else if viewModel.nodes.count <= 1 {
+      Text("この提案が参照している提案はありません")
+        .font(.footnote)
+        .foregroundStyle(.secondary)
+        .padding(8)
+        .background(.ultraThinMaterial, in: Capsule())
+        .padding(.top, 8)
+    }
+  }
+
+  @ViewBuilder
+  private func selectionBar(_ node: GraphNode) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 6) {
+        Text("#\(Int(node.id) ?? 0)")
+          .font(.caption)
+          .bold()
+        MarkdownText(node.title)
+          .font(.caption)
+          .lineLimit(2)
+        Spacer()
+      }
+      HStack(spacing: 12) {
+        if node.id != rootProposalId {
+          Button {
+            reRoot(to: node)
+          } label: {
+            Label("中心に", systemImage: "scope")
+          }
+        }
+        Spacer()
+        if let proposal = selectedProposal, proposal.proposalId == node.id {
+          NavigationLink(value: proposal) {
+            Label("クイズを開く", systemImage: "play.fill")
+          }
+        } else {
+          ProgressView()
+        }
+      }
+      .font(.callout)
+    }
+    .padding()
+    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+    .padding()
+  }
+
+  // MARK: - Helpers
+
+  private func screenPoint(_ point: CGPoint, center: CGPoint) -> CGPoint {
+    CGPoint(x: center.x + point.x, y: center.y + point.y)
+  }
+
+  private func reRoot(to node: GraphNode) {
+    selectedNode = nil
+    selectedProposal = nil
+    committedOffset = .zero
+    dragOffset = .zero
+    scale = 1
+    Task { await viewModel.load(rootProposalId: node.id, rootTitle: node.title) }
+  }
+
+  private func loadSelectedProposal() async {
+    guard let node = selectedNode else {
+      selectedProposal = nil
+      return
+    }
+    if selectedProposal?.proposalId == node.id { return }
+    selectedProposal = nil
+    selectedProposal = try? await seRepository.fetchProposals(byProposalIds: [node.id]).first
+  }
+}
+
+/// グラフ上の1ノード（提案番号 + 短縮タイトル）。
+private struct NodeChipView: View {
+  let node: GraphNode
+  let isRoot: Bool
+  let isSelected: Bool
+
+  var body: some View {
+    VStack(spacing: 2) {
+      Text("#\(Int(node.id) ?? 0)")
+        .font(.caption2)
+        .bold()
+      Text(node.title)
+        .font(.system(size: 9))
+        .lineLimit(1)
+        .frame(maxWidth: 90)
+    }
+    .padding(.horizontal, 8)
+    .padding(.vertical, 6)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(isRoot ? Color.accentColor.opacity(0.25) : Color.secondary.opacity(0.15))
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 8)
+        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+    )
+  }
+}

--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphViewModel.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphViewModel.swift
@@ -1,0 +1,103 @@
+//
+//  DependencyGraphViewModel.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/27.
+//
+
+import Foundation
+
+/// root 提案からの依存近傍を BFS で読み込み、放射状レイアウトを計算する。
+///
+/// エッジ取得とノード（title）取得をクロージャ注入にしているため、ネットワーク無しで単体テストできる。
+@MainActor
+final class DependencyGraphViewModel: ObservableObject {
+  typealias OutgoingFetch = @Sendable ([String]) async throws -> [GraphEdge]
+  typealias NodeFetch = @Sendable ([String]) async throws -> [GraphProposalNode]
+
+  @Published private(set) var nodes: [GraphNode] = []
+  @Published private(set) var edges: [GraphEdge] = []
+  @Published private(set) var layout = GraphLayout(positions: [:])
+  @Published private(set) var isLoading = false
+  @Published private(set) var loadError: String?
+
+  let maxHops: Int
+  let maxNodes: Int
+  let ringSpacing: CGFloat
+  private let outgoingFetch: OutgoingFetch
+  private let nodeFetch: NodeFetch
+
+  init(
+    maxHops: Int = 1,
+    maxNodes: Int = 40,
+    ringSpacing: CGFloat = 140,
+    outgoingFetch: @escaping OutgoingFetch = { ids in
+      let refs = try await ProposalReferenceRepository().fetchOutgoing(fromProposalIds: ids)
+      return refs.map { GraphEdge(from: $0.fromProposalId, to: $0.toProposalId) }
+    },
+    nodeFetch: @escaping NodeFetch = { ids in
+      try await SERepository().fetchGraphNodes(byProposalIds: ids)
+    }
+  ) {
+    self.maxHops = maxHops
+    self.maxNodes = maxNodes
+    self.ringSpacing = ringSpacing
+    self.outgoingFetch = outgoingFetch
+    self.nodeFetch = nodeFetch
+  }
+
+  func load(rootProposalId: String, rootTitle: String) async {
+    isLoading = true
+    loadError = nil
+    defer { isLoading = false }
+
+    var visited: Set<String> = [rootProposalId]
+    var collectedNodes: [GraphNode] = [GraphNode(id: rootProposalId, title: rootTitle, hop: 0)]
+    var collectedEdges: Set<GraphEdge> = []
+    var frontier: [String] = [rootProposalId]
+
+    do {
+      var hop = 1
+      while hop <= max(maxHops, 1), !frontier.isEmpty, collectedNodes.count < maxNodes {
+        let frontierSet = Set(frontier)
+        let outgoing = try await outgoingFetch(frontier)
+
+        // 現フロンティアを起点とするエッジを収集（循環・交差リンクも含む）
+        for edge in outgoing where frontierSet.contains(edge.from) {
+          collectedEdges.insert(edge)
+        }
+
+        let nextIds = outgoing.map(\.to).filter { !visited.contains($0) }
+        let batch = Array(Set(nextIds)).sorted()
+        guard !batch.isEmpty else { break }
+
+        let fetchedNodes = try await nodeFetch(batch)
+        let titleById = Dictionary(
+          fetchedNodes.map { ($0.proposalId, $0.title) },
+          uniquingKeysWith: { first, _ in first }
+        )
+
+        var newFrontier: [String] = []
+        for pid in batch {
+          guard collectedNodes.count < maxNodes else { break }
+          guard !visited.contains(pid) else { continue }
+          visited.insert(pid)
+          collectedNodes.append(GraphNode(id: pid, title: titleById[pid] ?? "SE-\(pid)", hop: hop))
+          newFrontier.append(pid)
+        }
+        frontier = newFrontier
+        hop += 1
+      }
+
+      // 両端が実在ノードであるエッジだけ残す（maxNodes で打ち切られた先のエッジを除外）
+      let nodeIds = Set(collectedNodes.map(\.id))
+      let prunedEdges = collectedEdges.filter { nodeIds.contains($0.from) && nodeIds.contains($0.to) }
+
+      nodes = collectedNodes
+      edges = Array(prunedEdges)
+      layout = RadialLayout.compute(nodes: collectedNodes, center: .zero, ringSpacing: ringSpacing)
+    } catch {
+      loadError = error.localizedDescription
+    }
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -193,6 +193,12 @@ struct ProposalListScreen: View {
         analytics: analytics
       )
     }
+    .navigationDestination(for: DependencyGraphRoute.self) { route in
+      DependencyGraphScreen(
+        rootProposalId: route.rootProposalId,
+        rootTitle: route.rootTitle
+      )
+    }
     .toolbar {
       #if os(iOS)
         ToolbarItem(placement: .topBarLeading) {

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct ProposalQuizView: View {
 
   @Environment(\.llmService) var llmService
+  @Environment(\.seRepository) var seRepository
+  @Environment(\.referenceRepository) var referenceRepository
 
   @State private var modalWebUrl: URL?
   @StateObject var quizViewModel: QuizViewModel
@@ -18,6 +20,7 @@ struct ProposalQuizView: View {
   @State private var showsLLMQuizView = false
   @State private var showsModelRequiredAlert = false
   @State private var isModelAvailable = false
+  @State private var relatedProposals: [SwiftEvolution] = []
 
   let proposal: SwiftEvolution
 
@@ -58,6 +61,37 @@ struct ProposalQuizView: View {
         .padding()
       }
 
+      if !relatedProposals.isEmpty {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("先に読むと理解しやすい提案")
+            .font(.caption)
+            .foregroundColor(.secondary)
+            .padding(.horizontal)
+          ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+              ForEach(relatedProposals) { related in
+                NavigationLink(value: related) {
+                  HStack(spacing: 4) {
+                    Text("#\(Int(related.proposalId) ?? 0)")
+                      .font(.caption2)
+                      .bold()
+                    MarkdownText(related.title)
+                      .font(.caption2)
+                      .lineLimit(1)
+                  }
+                  .padding(.horizontal, 10)
+                  .padding(.vertical, 6)
+                  .background(Capsule().fill(Color.secondary.opacity(0.12)))
+                }
+                .buttonStyle(.plain)
+              }
+            }
+            .padding(.horizontal)
+          }
+        }
+        .padding(.vertical, 4)
+      }
+
       DefaultWebView(
         htmlContent: .string(proposal.content),
         onNavigate: { url in
@@ -79,6 +113,17 @@ struct ProposalQuizView: View {
       .navigationBarTitleDisplayMode(.inline)
     #endif
     .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        NavigationLink(
+          value: DependencyGraphRoute(
+            rootProposalId: proposal.proposalId,
+            rootTitle: proposal.title
+          )
+        ) {
+          Image(systemName: "point.3.connected.trianglepath.dotted")
+            .accessibilityLabel("依存グラフ")
+        }
+      }
       ToolbarItem(placement: .primaryAction) {
         Button {
           if quizViewModel.hasLLMQuizzes {
@@ -118,6 +163,9 @@ struct ProposalQuizView: View {
     .task {
       await quizViewModel.configure()
     }
+    .task {
+      await loadRelatedProposals()
+    }
     .onAppear {
       Task {
         isModelAvailable = await llmService.isModelDownloaded(named: LLMModelConfig.modelId)
@@ -138,6 +186,20 @@ struct ProposalQuizView: View {
       }
     } message: {
       Text("このプロポーザルのクイズの進捗をリセットしますか？\nこの操作は取り消せません。")
+    }
+  }
+
+  /// この提案が参照している（理解の前提となる）提案を読み込む
+  private func loadRelatedProposals() async {
+    do {
+      let edges = try await referenceRepository.fetchOutgoing(fromProposalIds: [proposal.proposalId])
+      let ids = Array(Set(edges.map(\.toProposalId))).sorted()
+      guard !ids.isEmpty else { return }
+      let fetched = try await seRepository.fetchProposals(byProposalIds: ids)
+      relatedProposals = fetched.sorted { $0.proposalId < $1.proposalId }
+    } catch {
+      // 失敗時は前提提案を出さずにクイズ表示を継続
+      print("Failed to load related proposals:", error)
     }
   }
 }

--- a/ios/se-masked-quiz/Repositories/ProposalReferenceRepository.swift
+++ b/ios/se-masked-quiz/Repositories/ProposalReferenceRepository.swift
@@ -1,0 +1,67 @@
+//
+//  ProposalReferenceRepository.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/27.
+//
+
+import Foundation
+import SwiftUI
+
+/// proposal-references コレクションの1辺（from が to を参照する有向エッジ）。
+struct PayloadReference: Decodable, Sendable, Hashable {
+  let fromProposalId: String
+  let toProposalId: String
+}
+
+/// proposal 間の依存（参照）エッジを取得するリポジトリ。
+/// 順方向（from 起点）＝前提提案・グラフ outgoing、逆方向（to 起点）＝影響範囲。
+struct ProposalReferenceRepository: Sendable {
+  private static let fetchLimit = 1000
+
+  /// 指定した proposal 群が「参照している」エッジ（outgoing）を取得する。
+  func fetchOutgoing(fromProposalIds ids: [String]) async throws -> [PayloadReference] {
+    try await fetch(field: "fromProposalId", ids: ids)
+  }
+
+  /// 指定した proposal 群を「参照している」エッジ（incoming）を取得する。
+  func fetchIncoming(toProposalIds ids: [String]) async throws -> [PayloadReference] {
+    try await fetch(field: "toProposalId", ids: ids)
+  }
+
+  private func fetch(field: String, ids: [String]) async throws -> [PayloadReference] {
+    guard !ids.isEmpty else { return [] }
+    var result: [PayloadReference] = []
+    for chunk in PayloadHTTP.chunked(ids, size: 50) {
+      let url = try Self.referencesURL(baseURL: Env.serverBaseURL, field: field, ids: chunk)
+      let decoded: PayloadListResponse<PayloadReference> = try await PayloadHTTP.get(url)
+      result.append(contentsOf: decoded.docs)
+    }
+    return result
+  }
+
+  static func referencesURL(baseURL: String, field: String, ids: [String]) throws -> URL {
+    var components = try PayloadHTTP.components(baseURL: baseURL, path: "/api/proposal-references")
+    components.queryItems = [
+      URLQueryItem(name: "where[\(field)][in]", value: ids.joined(separator: ",")),
+      URLQueryItem(name: "limit", value: String(fetchLimit)),
+    ]
+    guard let url = components.url else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    return url
+  }
+}
+
+extension ProposalReferenceRepository: EnvironmentKey {
+  static var defaultValue: Self {
+    ProposalReferenceRepository()
+  }
+}
+
+extension EnvironmentValues {
+  var referenceRepository: ProposalReferenceRepository {
+    get { self[ProposalReferenceRepository.self] }
+    set { self[ProposalReferenceRepository.self] = newValue }
+  }
+}

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -81,6 +81,31 @@ struct SERepository: Sendable {
     }
   }
 
+  /// 複数の提案IDをまとめて取得する（前提提案チップ用。本文含むフル取得）
+  func fetchProposals(byProposalIds ids: [String]) async throws -> [SwiftEvolution] {
+    guard !ids.isEmpty else { return [] }
+    var result: [SwiftEvolution] = []
+    for chunk in PayloadHTTP.chunked(ids, size: 50) {
+      let url = try Self.proposalsByIdsURL(baseURL: Env.serverBaseURL, proposalIds: chunk)
+      let decoded: PayloadListResponse<PayloadProposal> = try await PayloadHTTP.get(url)
+      result.append(contentsOf: decoded.docs.map { $0.toSwiftEvolution() })
+    }
+    return result
+  }
+
+  /// グラフ描画用に提案IDから軽量ノード（proposalId/title のみ）を取得する。
+  /// `select` で巨大な content を転送しない。
+  func fetchGraphNodes(byProposalIds ids: [String]) async throws -> [GraphProposalNode] {
+    guard !ids.isEmpty else { return [] }
+    var result: [GraphProposalNode] = []
+    for chunk in PayloadHTTP.chunked(ids, size: 50) {
+      let url = try Self.graphNodesURL(baseURL: Env.serverBaseURL, proposalIds: chunk)
+      let decoded: PayloadListResponse<PayloadProposalNode> = try await PayloadHTTP.get(url)
+      result.append(contentsOf: decoded.docs.map { GraphProposalNode(proposalId: $0.proposalId, title: $0.title) })
+    }
+    return result
+  }
+
   /// 提案IDを指定して単一の提案を取得する（デイリーチャレンジ用）
   func fetchProposal(byProposalId proposalId: String) async throws -> SwiftEvolution? {
     let baseURL = Env.serverBaseURL
@@ -145,6 +170,92 @@ struct SERepository: Sendable {
     }
     return url
   }
+
+  static func proposalsByIdsURL(baseURL: String, proposalIds: [String]) throws -> URL {
+    var components = try PayloadHTTP.components(baseURL: baseURL, path: "/api/proposals")
+    components.queryItems = [
+      URLQueryItem(name: "where[proposalId][in]", value: proposalIds.joined(separator: ",")),
+      URLQueryItem(name: "limit", value: String(max(proposalIds.count, 1))),
+    ]
+    guard let url = components.url else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    return url
+  }
+
+  static func graphNodesURL(baseURL: String, proposalIds: [String]) throws -> URL {
+    var components = try PayloadHTTP.components(baseURL: baseURL, path: "/api/proposals")
+    components.queryItems = [
+      URLQueryItem(name: "where[proposalId][in]", value: proposalIds.joined(separator: ",")),
+      URLQueryItem(name: "select[proposalId]", value: "true"),
+      URLQueryItem(name: "select[title]", value: "true"),
+      URLQueryItem(name: "limit", value: String(max(proposalIds.count, 1))),
+    ]
+    guard let url = components.url else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    return url
+  }
+}
+
+// MARK: - Shared Payload HTTP helpers
+
+/// 認証ヘッダ付き GET と共通デコードをまとめた Payload REST のヘルパー。
+enum PayloadHTTP {
+  static func components(baseURL: String, path: String) throws -> URLComponents {
+    var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    while trimmed.hasSuffix("/") {
+      trimmed.removeLast()
+    }
+    guard let components = URLComponents(string: "\(trimmed)\(path)") else {
+      throw SERepositoryError.invalidBaseURL
+    }
+    return components
+  }
+
+  static func get<T: Decodable & Sendable>(_ url: URL) async throws -> T {
+    var request = URLRequest(url: url)
+    request.httpMethod = "GET"
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("users API-Key \(Env.serverApiKey)", forHTTPHeaderField: "Authorization")
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let http = response as? HTTPURLResponse else {
+      throw SERepositoryError.httpStatus(-1)
+    }
+    guard (200 ... 299).contains(http.statusCode) else {
+      throw SERepositoryError.httpStatus(http.statusCode)
+    }
+    guard !data.isEmpty else {
+      throw SERepositoryError.emptyResponseBody
+    }
+    do {
+      return try JSONDecoder().decode(T.self, from: data)
+    } catch {
+      throw SERepositoryError.decodingFailed
+    }
+  }
+
+  /// `where[...][in]` のリストが長くなりすぎないよう一定数で分割する。
+  static func chunked(_ ids: [String], size: Int) -> [[String]] {
+    guard size > 0 else { return ids.isEmpty ? [] : [ids] }
+    return stride(from: 0, to: ids.count, by: size).map {
+      Array(ids[$0 ..< min($0 + size, ids.count)])
+    }
+  }
+}
+
+// MARK: - Graph node models
+
+/// `select` で title のみ取得した軽量な提案ノード。
+struct PayloadProposalNode: Decodable, Sendable {
+  let proposalId: String
+  let title: String
+}
+
+struct GraphProposalNode: Sendable, Hashable, Identifiable {
+  var id: String { proposalId }
+  let proposalId: String
+  let title: String
 }
 
 // MARK: - Payload REST API Response Models

--- a/ios/se-masked-quizTests/DependencyGraphViewModelTests.swift
+++ b/ios/se-masked-quizTests/DependencyGraphViewModelTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import Testing
+@testable import se_masked_quiz
+
+@MainActor
+@Suite("DependencyGraphViewModel / BFS + layout")
+struct DependencyGraphViewModelTests {
+
+  /// メモリ上の隣接リストでエッジ/ノード取得を差し替えた ViewModel を作る。
+  private func makeViewModel(
+    adjacency: [String: [String]],
+    titles: [String: String],
+    maxHops: Int = 1,
+    maxNodes: Int = 40
+  ) -> DependencyGraphViewModel {
+    DependencyGraphViewModel(
+      maxHops: maxHops,
+      maxNodes: maxNodes,
+      outgoingFetch: { ids in
+        ids.flatMap { from in (adjacency[from] ?? []).map { GraphEdge(from: from, to: $0) } }
+      },
+      nodeFetch: { ids in
+        ids.map { GraphProposalNode(proposalId: $0, title: titles[$0] ?? "SE-\($0)") }
+      }
+    )
+  }
+
+  @Test("hop1: root の参照先がノードとエッジになる")
+  func hop1() async {
+    let viewModel = makeViewModel(
+      adjacency: ["0304": ["0296", "0306"]],
+      titles: ["0296": "Async", "0306": "Actors"]
+    )
+    await viewModel.load(rootProposalId: "0304", rootTitle: "Structured Concurrency")
+    #expect(Set(viewModel.nodes.map(\.id)) == ["0304", "0296", "0306"])
+    #expect(viewModel.edges.count == 2)
+    #expect(viewModel.nodes.first { $0.id == "0304" }?.hop == 0)
+    #expect(viewModel.nodes.first { $0.id == "0296" }?.hop == 1)
+  }
+
+  @Test("循環参照でも有限のノード集合になり、両方向エッジを保持する")
+  func cycle() async {
+    let viewModel = makeViewModel(
+      adjacency: ["A": ["B"], "B": ["A"]],
+      titles: ["A": "a", "B": "b"],
+      maxHops: 3
+    )
+    await viewModel.load(rootProposalId: "A", rootTitle: "a")
+    #expect(Set(viewModel.nodes.map(\.id)) == ["A", "B"])
+    #expect(viewModel.edges.contains(GraphEdge(from: "A", to: "B")))
+    #expect(viewModel.edges.contains(GraphEdge(from: "B", to: "A")))
+  }
+
+  @Test("参照が無い場合は root ノードのみ")
+  func emptyNeighborhood() async {
+    let viewModel = makeViewModel(adjacency: ["X": []], titles: [:])
+    await viewModel.load(rootProposalId: "X", rootTitle: "x")
+    #expect(viewModel.nodes.count == 1)
+    #expect(viewModel.edges.isEmpty)
+  }
+
+  @Test("maxNodes でノード数が制限される")
+  func nodeCap() async {
+    let many = (1 ... 100).map { String(format: "%04d", $0) }
+    let viewModel = makeViewModel(
+      adjacency: ["0000": many],
+      titles: [:],
+      maxHops: 1,
+      maxNodes: 10
+    )
+    await viewModel.load(rootProposalId: "0000", rootTitle: "root")
+    #expect(viewModel.nodes.count <= 10)
+  }
+
+  @Test("RadialLayout: root は中心、hop1 ノードは半径 ringSpacing 上に並ぶ")
+  func radialLayout() throws {
+    let nodes = [
+      GraphNode(id: "R", title: "r", hop: 0),
+      GraphNode(id: "A", title: "a", hop: 1),
+      GraphNode(id: "B", title: "b", hop: 1),
+    ]
+    let layout = RadialLayout.compute(nodes: nodes, center: .zero, ringSpacing: 100)
+    #expect(layout.positions["R"] == .zero)
+    let a = try #require(layout.positions["A"])
+    let b = try #require(layout.positions["B"])
+    #expect(abs(hypot(a.x, a.y) - 100) < 0.0001)
+    #expect(abs(hypot(b.x, b.y) - 100) < 0.0001)
+  }
+}

--- a/ios/se-masked-quizTests/ProposalReferenceRepositoryTests.swift
+++ b/ios/se-masked-quizTests/ProposalReferenceRepositoryTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+@testable import se_masked_quiz
+
+@Suite("ProposalReferenceRepository / proposal-references REST API")
+struct ProposalReferenceRepositoryTests {
+
+  @Test("PayloadReference をデコードできる")
+  func decodeReference() throws {
+    let json = """
+    {
+      "docs": [ { "id": 1, "fromProposalId": "0304", "toProposalId": "0296" } ],
+      "totalDocs": 1, "limit": 1000, "totalPages": 1, "page": 1,
+      "hasNextPage": false, "hasPrevPage": false
+    }
+    """
+    let data = try #require(json.data(using: .utf8))
+    let response = try JSONDecoder().decode(PayloadListResponse<PayloadReference>.self, from: data)
+    let first = try #require(response.docs.first)
+    #expect(first.fromProposalId == "0304")
+    #expect(first.toProposalId == "0296")
+  }
+
+  @Test("outgoing は where[fromProposalId][in] とカンマ区切りIDを生成する")
+  func outgoingURL() throws {
+    let url = try ProposalReferenceRepository.referencesURL(
+      baseURL: "https://example.com/",
+      field: "fromProposalId",
+      ids: ["0304", "0306"]
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "where[fromProposalId][in]", value: "0304,0306")))
+    #expect(items.contains(URLQueryItem(name: "limit", value: "1000")))
+  }
+
+  @Test("incoming は where[toProposalId][in] を生成する")
+  func incomingURL() throws {
+    let url = try ProposalReferenceRepository.referencesURL(
+      baseURL: "https://example.com",
+      field: "toProposalId",
+      ids: ["0304"]
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "where[toProposalId][in]", value: "0304")))
+  }
+}

--- a/ios/se-masked-quizTests/SERepositoryTests.swift
+++ b/ios/se-masked-quizTests/SERepositoryTests.swift
@@ -141,6 +141,57 @@ struct SERepositoryTests {
     #expect(!query.contains("where"))
   }
 
+  @Test("proposalsByIdsURL は where[proposalId][in] とカンマ区切りIDを含む")
+  func proposalsByIdsURL() throws {
+    let url = try SERepository.proposalsByIdsURL(
+      baseURL: "https://example.com/",
+      proposalIds: ["0005", "0023"]
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "where[proposalId][in]", value: "0005,0023")))
+    #expect(items.contains(URLQueryItem(name: "limit", value: "2")))
+  }
+
+  @Test("graphNodesURL は in と select[proposalId]/select[title] を含み content を要求しない")
+  func graphNodesURL() throws {
+    let url = try SERepository.graphNodesURL(
+      baseURL: "https://example.com",
+      proposalIds: ["0005", "0023"]
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "where[proposalId][in]", value: "0005,0023")))
+    #expect(items.contains(URLQueryItem(name: "select[proposalId]", value: "true")))
+    #expect(items.contains(URLQueryItem(name: "select[title]", value: "true")))
+    let query = url.query ?? ""
+    #expect(!query.contains("select%5Bcontent%5D"))
+  }
+
+  @Test("PayloadProposalNode を select レスポンスからデコードできる（content 不要）")
+  func decodeGraphNode() throws {
+    let json = """
+    {
+      "docs": [ { "id": 7, "proposalId": "0304", "title": "Structured Concurrency" } ],
+      "totalDocs": 1, "limit": 1, "totalPages": 1, "page": 1,
+      "hasNextPage": false, "hasPrevPage": false
+    }
+    """
+    let data = try #require(json.data(using: .utf8))
+    let response = try JSONDecoder().decode(PayloadListResponse<PayloadProposalNode>.self, from: data)
+    let first = try #require(response.docs.first)
+    #expect(first.proposalId == "0304")
+    #expect(first.title == "Structured Concurrency")
+  }
+
+  @Test("PayloadHTTP.chunked は指定サイズで分割する")
+  func chunked() {
+    let ids = (1 ... 5).map { String($0) }
+    let chunks = PayloadHTTP.chunked(ids, size: 2)
+    #expect(chunks.count == 3)
+    #expect(chunks.first == ["1", "2"])
+    #expect(chunks.last == ["5"])
+    #expect(PayloadHTTP.chunked([], size: 2).isEmpty)
+  }
+
   @Test("ページネーション情報を正しくデコードできる")
   func decodePagination() throws {
     let json = """

--- a/server/migrations/0002_proposal_references.sql
+++ b/server/migrations/0002_proposal_references.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `proposal_references` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `from_proposal_id` text NOT NULL,
+  `to_proposal_id` text NOT NULL,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+CREATE UNIQUE INDEX `proposal_references_from_to_idx` ON `proposal_references` (`from_proposal_id`, `to_proposal_id`);
+CREATE INDEX `proposal_references_from_idx` ON `proposal_references` (`from_proposal_id`);
+CREATE INDEX `proposal_references_to_idx` ON `proposal_references` (`to_proposal_id`);
+CREATE INDEX `proposal_references_updated_at_idx` ON `proposal_references` (`updated_at`);
+CREATE INDEX `proposal_references_created_at_idx` ON `proposal_references` (`created_at`);
+
+-- Payload's locked-documents join table needs a column per collection.
+ALTER TABLE `payload_locked_documents_rels` ADD COLUMN `proposal_references_id` integer REFERENCES `proposal_references`(`id`);
+CREATE INDEX `payload_locked_documents_rels_proposal_references_id_idx` ON `payload_locked_documents_rels` (`proposal_references_id`);

--- a/server/src/collections/ProposalReferences.ts
+++ b/server/src/collections/ProposalReferences.ts
@@ -1,0 +1,41 @@
+import type { CollectionConfig } from 'payload';
+
+const PROPOSAL_ID_PATTERN = /^\d{4}$/;
+
+const validateProposalId = (value: unknown) => {
+	if (typeof value !== 'string' || !PROPOSAL_ID_PATTERN.test(value)) {
+		return 'proposalId must be four digits (e.g. 0001)';
+	}
+	return true;
+};
+
+// A single directed edge of the proposal dependency graph: `from` references `to`.
+// Stored normalized (one row per edge) so both directions are index-queryable.
+export const ProposalReferences: CollectionConfig = {
+	slug: 'proposal-references',
+	admin: {
+		useAsTitle: 'fromProposalId',
+	},
+	access: {
+		read: () => true,
+		create: ({ req }) => !!req.user,
+		update: ({ req }) => !!req.user,
+		delete: ({ req }) => !!req.user,
+	},
+	fields: [
+		{
+			name: 'fromProposalId',
+			type: 'text',
+			required: true,
+			index: true,
+			validate: validateProposalId,
+		},
+		{
+			name: 'toProposalId',
+			type: 'text',
+			required: true,
+			index: true,
+			validate: validateProposalId,
+		},
+	],
+};

--- a/server/src/payload.config.ts
+++ b/server/src/payload.config.ts
@@ -1,93 +1,89 @@
-import fs from 'fs'
-import path from 'path'
-import { sqliteD1Adapter } from '@payloadcms/db-d1-sqlite'
-import { lexicalEditor } from '@payloadcms/richtext-lexical'
-import { buildConfig } from 'payload'
-import { fileURLToPath } from 'url'
-import type { CloudflareContext } from '@opennextjs/cloudflare'
-import { getCloudflareContext } from '@opennextjs/cloudflare'
-import type { GetPlatformProxyOptions } from 'wrangler'
+import fs from 'fs';
+import path from 'path';
+import { sqliteD1Adapter } from '@payloadcms/db-d1-sqlite';
+import { lexicalEditor } from '@payloadcms/richtext-lexical';
+import { buildConfig } from 'payload';
+import { fileURLToPath } from 'url';
+import type { CloudflareContext } from '@opennextjs/cloudflare';
+import { getCloudflareContext } from '@opennextjs/cloudflare';
+import type { GetPlatformProxyOptions } from 'wrangler';
 
-import { Proposals } from './collections/Proposals'
-import { QuizAnswers } from './collections/QuizAnswers'
-import { Users } from './collections/Users'
+import { Proposals } from './collections/Proposals';
+import { ProposalReferences } from './collections/ProposalReferences';
+import { QuizAnswers } from './collections/QuizAnswers';
+import { Users } from './collections/Users';
 
-const filename = fileURLToPath(import.meta.url)
-const dirname = path.dirname(filename)
+const filename = fileURLToPath(import.meta.url);
+const dirname = path.dirname(filename);
 const realpath = (value: string) => {
-  const resolved = fs.existsSync(value) ? fs.realpathSync(value) : undefined
-  return resolved
-}
+	const resolved = fs.existsSync(value) ? fs.realpathSync(value) : undefined;
+	return resolved;
+};
 
-const isCLI = process.argv.some((value) => realpath(value)?.endsWith(path.join('payload', 'bin.js')))
-const isProduction = process.env.NODE_ENV === 'production'
+const isCLI = process.argv.some((value) => realpath(value)?.endsWith(path.join('payload', 'bin.js')));
+const isProduction = process.env.NODE_ENV === 'production';
 
 // Custom JSON logger for Cloudflare Workers (pino-pretty is not supported)
-const createLog =
-  (level: string, fn: typeof console.log) => (objOrMsg: object | string, msg?: string) => {
-    if (typeof objOrMsg === 'string') {
-      fn(JSON.stringify({ level, msg: objOrMsg }))
-    } else {
-      fn(JSON.stringify({ level, ...objOrMsg, msg: msg ?? (objOrMsg as { msg?: string }).msg }))
-    }
-  }
+const createLog = (level: string, fn: typeof console.log) => (objOrMsg: object | string, msg?: string) => {
+	if (typeof objOrMsg === 'string') {
+		fn(JSON.stringify({ level, msg: objOrMsg }));
+	} else {
+		fn(JSON.stringify({ level, ...objOrMsg, msg: msg ?? (objOrMsg as { msg?: string }).msg }));
+	}
+};
 
 const cloudflareLogger = {
-  level: process.env.PAYLOAD_LOG_LEVEL || 'info',
-  trace: createLog('trace', console.debug),
-  debug: createLog('debug', console.debug),
-  info: createLog('info', console.log),
-  warn: createLog('warn', console.warn),
-  error: createLog('error', console.error),
-  fatal: createLog('fatal', console.error),
-  silent: () => {},
-} as any
+	level: process.env.PAYLOAD_LOG_LEVEL || 'info',
+	trace: createLog('trace', console.debug),
+	debug: createLog('debug', console.debug),
+	info: createLog('info', console.log),
+	warn: createLog('warn', console.warn),
+	error: createLog('error', console.error),
+	fatal: createLog('fatal', console.error),
+	silent: () => {},
+} as any;
 
 function getCloudflareContextFromWrangler(): Promise<CloudflareContext> {
-  return import(/* webpackIgnore: true */ `${'__wrangler'.replaceAll('_', '')}`).then(
-    ({ getPlatformProxy }) =>
-      getPlatformProxy({
-        environment: process.env.CLOUDFLARE_ENV,
-        remoteBindings: isProduction,
-      } satisfies GetPlatformProxyOptions),
-  )
+	return import(/* webpackIgnore: true */ `${'__wrangler'.replaceAll('_', '')}`).then(({ getPlatformProxy }) =>
+		getPlatformProxy({
+			environment: process.env.CLOUDFLARE_ENV,
+			remoteBindings: isProduction,
+		} satisfies GetPlatformProxyOptions),
+	);
 }
 
-const cloudflare =
-  isCLI || !isProduction
-    ? await getCloudflareContextFromWrangler()
-    : await getCloudflareContext({ async: true })
+const cloudflare = isCLI || !isProduction ? await getCloudflareContextFromWrangler() : await getCloudflareContext({ async: true });
 
 // Cloudflare Workers Builds does not expose runtime secrets during `next build`,
 // so the secret is only enforced at runtime. The placeholder is never used in
 // production: at runtime the real secret is required or startup fails below.
-const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build'
+const isBuildPhase = process.env.NEXT_PHASE === 'phase-production-build';
 
 if (!isBuildPhase && !process.env.PAYLOAD_SECRET) {
-  throw new Error('PAYLOAD_SECRET environment variable is required')
+	throw new Error('PAYLOAD_SECRET environment variable is required');
 }
 
 export default buildConfig({
-  secret: process.env.PAYLOAD_SECRET || 'build-time-placeholder-never-used-at-runtime',
-  db: sqliteD1Adapter({
-    binding: cloudflare.env.DB,
-  }),
-  editor: lexicalEditor(),
-  collections: [Users, Proposals, QuizAnswers],
-  logger: isProduction ? cloudflareLogger : undefined,
-  // iOS app is the only client; browsers must not be able to call this API.
-  cors: [],
-  csrf: [],
-  graphQL: {
-    disable: true,
-  },
-  admin: {
-    user: Users.slug,
-    importMap: {
-      baseDir: path.resolve(dirname),
-    },
-  },
-  typescript: {
-    outputFile: path.resolve(dirname, 'payload-types.ts'),
-  },
-})
+	secret: process.env.PAYLOAD_SECRET || 'build-time-placeholder-never-used-at-runtime',
+	db: sqliteD1Adapter({
+		binding: cloudflare.env.DB,
+	}),
+	editor: lexicalEditor(),
+	collections: [Users, Proposals, QuizAnswers, ProposalReferences],
+	logger: isProduction ? cloudflareLogger : undefined,
+	// iOS app is the only client; browsers must not be able to call this API.
+	cors: [],
+	csrf: [],
+	graphQL: {
+		disable: true,
+	},
+	admin: {
+		user: Users.slug,
+		importMap: {
+			baseDir: path.resolve(dirname),
+		},
+	},
+	typescript: {
+		outputFile: path.resolve(dirname, 'payload-types.ts'),
+	},
+});

--- a/server/test/index.spec.ts
+++ b/server/test/index.spec.ts
@@ -1,36 +1,55 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect } from 'vitest';
 
 describe('Payload CMS Configuration', () => {
-  it('collections are defined', async () => {
-    const { Proposals } = await import('../src/collections/Proposals')
-    const { QuizAnswers } = await import('../src/collections/QuizAnswers')
-    const { Users } = await import('../src/collections/Users')
+	it('collections are defined', async () => {
+		const { Proposals } = await import('../src/collections/Proposals');
+		const { QuizAnswers } = await import('../src/collections/QuizAnswers');
+		const { Users } = await import('../src/collections/Users');
 
-    expect(Proposals.slug).toBe('proposals')
-    expect(QuizAnswers.slug).toBe('quiz-answers')
-    expect(Users.slug).toBe('users')
-  })
+		expect(Proposals.slug).toBe('proposals');
+		expect(QuizAnswers.slug).toBe('quiz-answers');
+		expect(Users.slug).toBe('users');
+	});
 
-  it('Proposals collection has required fields', async () => {
-    const { Proposals } = await import('../src/collections/Proposals')
-    const fieldNames = Proposals.fields.map((f) => ('name' in f ? f.name : ''))
-    expect(fieldNames).toContain('proposalId')
-    expect(fieldNames).toContain('title')
-    expect(fieldNames).toContain('authors')
-    expect(fieldNames).toContain('content')
-    expect(fieldNames).toContain('reviewManager')
-    expect(fieldNames).toContain('status')
-  })
+	it('Proposals collection has required fields', async () => {
+		const { Proposals } = await import('../src/collections/Proposals');
+		const fieldNames = Proposals.fields.map((f) => ('name' in f ? f.name : ''));
+		expect(fieldNames).toContain('proposalId');
+		expect(fieldNames).toContain('title');
+		expect(fieldNames).toContain('authors');
+		expect(fieldNames).toContain('content');
+		expect(fieldNames).toContain('reviewManager');
+		expect(fieldNames).toContain('status');
+	});
 
-  it('QuizAnswers collection has required fields', async () => {
-    const { QuizAnswers } = await import('../src/collections/QuizAnswers')
-    const fieldNames = QuizAnswers.fields.map((f) => ('name' in f ? f.name : ''))
-    expect(fieldNames).toContain('proposalId')
-    expect(fieldNames).toContain('answers')
-  })
+	it('QuizAnswers collection has required fields', async () => {
+		const { QuizAnswers } = await import('../src/collections/QuizAnswers');
+		const fieldNames = QuizAnswers.fields.map((f) => ('name' in f ? f.name : ''));
+		expect(fieldNames).toContain('proposalId');
+		expect(fieldNames).toContain('answers');
+	});
 
-  it('Users collection has API key auth enabled', async () => {
-    const { Users } = await import('../src/collections/Users')
-    expect(Users.auth).toEqual({ useAPIKey: true })
-  })
-})
+	it('Users collection has API key auth enabled', async () => {
+		const { Users } = await import('../src/collections/Users');
+		expect(Users.auth).toEqual({ useAPIKey: true });
+	});
+
+	it('ProposalReferences collection has from/to fields', async () => {
+		const { ProposalReferences } = await import('../src/collections/ProposalReferences');
+		expect(ProposalReferences.slug).toBe('proposal-references');
+		const fieldNames = ProposalReferences.fields.map((f) => ('name' in f ? f.name : ''));
+		expect(fieldNames).toContain('fromProposalId');
+		expect(fieldNames).toContain('toProposalId');
+	});
+
+	it('ProposalReferences validates four-digit ids', async () => {
+		const { ProposalReferences } = await import('../src/collections/ProposalReferences');
+		const field = ProposalReferences.fields.find((f) => 'name' in f && f.name === 'fromProposalId') as {
+			validate: (value: unknown) => true | string;
+		};
+		expect(field.validate('0001')).toBe(true);
+		expect(typeof field.validate('SE-1')).toBe('string');
+		expect(typeof field.validate('12')).toBe('string');
+		expect(typeof field.validate(1234)).toBe('string');
+	});
+});


### PR DESCRIPTION
## Context
Issue #18: ある proposal を理解するには「先に読むべき proposal」があるが、どれを先に読むべきか分かりづらい。proposal 間の参照（依存）関係を可視化して解決する。

## データモデル
参照は**自己参照・有向の多対多**。正規化したエッジコレクション `proposal-references`（1行=1辺、`fromProposalId`/`toProposalId` の4桁文字列キー）で表現し、順/逆方向を index でクエリ可能にした。`proposals` テーブルは無改変。

- Payload `relationship` は内部整数 id で結ぶため、proposal を毎回 delete→create するパイプラインと相性が悪く不採用。安定キー `proposalId` を保つエッジ表方式を採用。

## 変更
**server**
- 新コレクション `proposal-references`（`server/src/collections/ProposalReferences.ts`）+ config 登録
- D1 マイグレーション `0002_proposal_references.sql`（from/to 両 index・複合 UNIQUE、`payload_locked_documents_rels` への列追加含む）

**iOS**
- `ProposalReferenceRepository`（順/逆方向のエッジ取得）
- `SERepository`: `where[..][in]` 一括取得 + `select` で content を省いた軽量ノード取得
- `ProposalQuizView`: 「先に読むと理解しやすい提案」チップ行
- `DependencyGraphScreen`（`GraphFeature/`）: root 近傍を BFS（既定 hop1/最大40ノード）、放射状レイアウト、pan/zoom、ノード選択で再ルート/クイズ起動

**pipeline（別PR）**
- 参照抽出とエッジ投入は submodule swift-evolution-masking: fummicc1/swift-evolution-masking#9

## 検証
- D1 マイグレーションをローカル適用し `PRAGMA` で列/ index を確認、`payload generate:types` で Payload がコレクションを受理することを確認
- 参照抽出を実 proposal で確認（例: SE-0304 → 8件）
- iOS: `xcodebuild` で **TEST BUILD SUCCEEDED**、ユニットテスト **93 passed / 0 failed**（新規: ProposalReferenceRepository / DependencyGraphViewModel / SERepository URL）

## デプロイ順序
**B(D1 migration を remote 適用) → A(pipeline 投入) → iOS**。iOS はエッジ未投入でも空チップ行・単一ノードグラフで安全。

## 未対応（環境制約）
- ローカル dev サーバでの REST 往復は未実施（config ブート+型生成で代替確認）
- server の vitest はこのリポジトリの依存に未宣言のためローカル実行不可（コレクションは型生成で検証）

Closes #18

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf