### PR TITLE
fix: クイズ回答後に一覧の進捗が更新されない不具合を修正

### DIFF
--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -24,11 +24,19 @@ struct ProposalListScreen: View {
   @State private var searchText: String = ""
   @State private var debouncedSearchText: String = ""
   @State private var sortOrder: ProposalSortOrder = .descending
+  @State private var navigationPath = NavigationPath()
 
   var body: some View {
     GeometryReader { proxy in
-      NavigationStack {
+      NavigationStack(path: $navigationPath) {
         proposalsList
+      }
+      // 詳細画面でクイズに回答して戻ってきたとき（path が縮む）に進捗を再読込し、
+      // 一覧の進捗率・正解率を最新化する
+      .onChange(of: navigationPath.count) { oldCount, newCount in
+        if newCount < oldCount {
+          Task { await loadQuizProgresses() }
+        }
       }
       .sheet(isPresented: $showsSetting) {
         SettingScreen()


### PR DESCRIPTION
## 不具合
ProposalList → proposal 詳細でクイズに回答 → 一覧へ戻った際、該当 proposal の進捗率・正解率が最新化されない。

## 原因
`ProposalListScreen` は進捗（`quizProgresses`）を初回 `.task` の `loadQuizProgresses()` でしか読み込んでおらず、詳細から戻っても再読込されないため古い値のまま表示されていた。スコア自体は回答ごとに `QuizRepositoryImpl.saveScore()` で UserDefaults に永続化されている。

## 修正
`NavigationStack` に path をバインドし、戻る操作（path の count 減少）を検知して `loadQuizProgresses()` を再実行する。

```swift
NavigationStack(path: $navigationPath) { proposalsList }
  .onChange(of: navigationPath.count) { oldCount, newCount in
    if newCount < oldCount { Task { await loadQuizProgresses() } }
  }
```

- スコアはローカル(UserDefaults)、クイズ件数は12hキャッシュのため再読込は安価。
- 既存の `NavigationLink(value:)`（proposal / daily / 依存グラフ）はそのまま path 経由で動作。

## 検証
- `xcodebuild build-for-testing` で **TEST BUILD SUCCEEDED**（既存ユニットテストに影響なし）。
- 手動: 一覧→proposal で回答→戻る、で進捗率/正解率が即時更新されることを確認（要 `Env.swift` 環境）。

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf