### PR TITLE
feat: Swift Testing 提案の取り込み（テーブル分離・タブUI）

### DIFF
--- a/ios/se-masked-quiz/Models/ProposalTrack.swift
+++ b/ios/se-masked-quiz/Models/ProposalTrack.swift
@@ -1,0 +1,57 @@
+//
+//  ProposalTrack.swift
+//  se-masked-quiz
+//
+//  Created by Fumiya Tanaka on 2025/06/28.
+//
+
+import Foundation
+
+/// 提案のトラック。Swift Evolution(SE) と Swift Testing(ST) を区別する。
+///
+/// バックエンドではトラックごとに別コレクション/エンドポイントに分かれており、proposalId は
+/// 各テーブル内で bare 4桁。`SE-`/`ST-` 接頭辞は表示専用で、取得元トラックから付与する。
+enum ProposalTrack: String, Sendable, Codable, Hashable, CaseIterable {
+  case swiftEvolution
+  case swiftTesting
+
+  /// 表示用の接頭辞（例: SE / ST）。
+  var displayPrefix: String {
+    switch self {
+    case .swiftEvolution: return "SE"
+    case .swiftTesting: return "ST"
+    }
+  }
+
+  /// タブ等に出すトラック名。
+  var title: String {
+    switch self {
+    case .swiftEvolution: return "Swift Evolution"
+    case .swiftTesting: return "Swift Testing"
+    }
+  }
+
+  /// Payload の proposals 系エンドポイントの slug。
+  var proposalsSlug: String {
+    switch self {
+    case .swiftEvolution: return "proposals"
+    case .swiftTesting: return "testing-proposals"
+    }
+  }
+
+  /// Payload の quiz-answers 系エンドポイントの slug。
+  var quizAnswersSlug: String {
+    switch self {
+    case .swiftEvolution: return "quiz-answers"
+    case .swiftTesting: return "testing-quiz-answers"
+    }
+  }
+
+  /// ローカル保存(UserDefaults)キーの名前空間。SE は従来キーのまま、ST は接頭辞で分離する。
+  var storageNamespace: String {
+    switch self {
+    case .swiftEvolution: return ""
+    case .swiftTesting: return "testing_"
+    }
+  }
+}

--- a/ios/se-masked-quiz/Models/SwiftEvolution.swift
+++ b/ios/se-masked-quiz/Models/SwiftEvolution.swift
@@ -19,4 +19,44 @@ struct SwiftEvolution: Sendable, Codable, Identifiable, Hashable {
   var authors: String
   // HTML format
   var content: String
+  // 取得元トラック（SE/ST）。表示接頭辞やクイズ取得先の判別に使う。
+  var track: ProposalTrack = .swiftEvolution
+
+  /// 表示用ID（例: SE-0001 / ST-0001）。proposalId はトラック内で bare 4桁のため接頭辞をここで付与。
+  var displayId: String {
+    "\(track.displayPrefix)-\(proposalId)"
+  }
+
+  init(
+    id: String,
+    proposalId: String,
+    title: String,
+    reviewManager: String?,
+    status: String?,
+    authors: String,
+    content: String,
+    track: ProposalTrack = .swiftEvolution
+  ) {
+    self.id = id
+    self.proposalId = proposalId
+    self.title = title
+    self.reviewManager = reviewManager
+    self.status = status
+    self.authors = authors
+    self.content = content
+    self.track = track
+  }
+
+  // 旧データ（track キー無し）でも安全にデコードできるよう track は省略可能扱いにする。
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    id = try c.decode(String.self, forKey: .id)
+    proposalId = try c.decode(String.self, forKey: .proposalId)
+    title = try c.decode(String.self, forKey: .title)
+    reviewManager = try c.decodeIfPresent(String.self, forKey: .reviewManager)
+    status = try c.decodeIfPresent(String.self, forKey: .status)
+    authors = try c.decode(String.self, forKey: .authors)
+    content = try c.decode(String.self, forKey: .content)
+    track = try c.decodeIfPresent(ProposalTrack.self, forKey: .track) ?? .swiftEvolution
+  }
 }

--- a/ios/se-masked-quiz/ProposalFeature/DailyChallengeCard.swift
+++ b/ios/se-masked-quiz/ProposalFeature/DailyChallengeCard.swift
@@ -32,7 +32,7 @@ struct DailyChallengeCard: View {
           .font(.headline)
           .lineLimit(2)
 
-        Text("SE-\(proposal.proposalId)")
+        Text(proposal.displayId)
           .font(.caption)
           .foregroundStyle(.secondary)
 

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProposalListScreen: View {
   @Environment(\.seRepository) var repository
   @Environment(\.quizRepository) var quizRepository
+  @Environment(\.testingQuizRepository) var testingQuizRepository
   @Environment(\.streakRepository) var streakRepository
   @Environment(\.analytics) var analytics
   @State private var proposals: AsyncProposals = .idle
@@ -25,6 +26,18 @@ struct ProposalListScreen: View {
   @State private var debouncedSearchText: String = ""
   @State private var sortOrder: ProposalSortOrder = .descending
   @State private var navigationPath = NavigationPath()
+
+  /// このタブのトラック（Swift Evolution / Swift Testing）。
+  let track: ProposalTrack
+
+  init(track: ProposalTrack = .swiftEvolution) {
+    self.track = track
+  }
+
+  /// トラックに対応するクイズリポジトリ（SE/ST でエンドポイント・ローカル保存が分かれる）。
+  private var activeQuizRepository: any QuizRepository {
+    track == .swiftEvolution ? quizRepository : testingQuizRepository
+  }
 
   var body: some View {
     GeometryReader { proxy in
@@ -54,11 +67,12 @@ struct ProposalListScreen: View {
                 let response = try await repository.fetch(
                   page: currentPage,
                   searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText,
-                  sortOrder: sortOrder
+                  sortOrder: sortOrder,
+                  track: track
                 )
                 hasNextPage = response.hasNextPage
                 var currentProposals = proposals.content
-                currentProposals.append(contentsOf: response.docs.map { $0.toSwiftEvolution() })
+                currentProposals.append(contentsOf: response.docs.map { $0.toSwiftEvolution(track: track) })
                 proposals = .loaded(currentProposals)
                 currentPage += 1
               } catch {
@@ -85,16 +99,18 @@ struct ProposalListScreen: View {
         }
         do {
           proposals.startLoading()
-          let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder)
+          let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder, track: track)
           hasNextPage = response.hasNextPage
-          self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution() })
+          self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution(track: track) })
           currentPage += 1
 
           // 進捗情報を読み込む
           await loadQuizProgresses()
 
-          // 今日のチャレンジを読み込む
-          await loadDailyChallenge()
+          // 今日のチャレンジを読み込む（Swift Evolution タブのみ）
+          if track == .swiftEvolution {
+            await loadDailyChallenge()
+          }
         } catch {
           self.proposals = .error(error)
         }
@@ -159,7 +175,7 @@ struct ProposalListScreen: View {
             HStack {
               MarkdownText(proposal.title)
                 .font(.headline)
-              Text("#\(Int(proposal.proposalId) ?? 0)")
+              Text(proposal.displayId)
                 .font(.caption)
             }
             MarkdownText(proposal.status ?? "")
@@ -191,12 +207,12 @@ struct ProposalListScreen: View {
         ContentUnavailableView.search(text: debouncedSearchText)
       }
     }
-    .navigationTitle("Swift Evolution")
+    .navigationTitle(track.title)
     .modifier(ProposalListSearchableModifier(searchText: $searchText))
     .navigationDestination(for: SwiftEvolution.self) { proposal in
       ProposalQuizView(
         proposal: proposal,
-        quizRepository: quizRepository,
+        quizRepository: proposal.track == .swiftEvolution ? quizRepository : testingQuizRepository,
         streakRepository: streakRepository,
         analytics: analytics
       )
@@ -257,10 +273,11 @@ struct ProposalListScreen: View {
         let response = try await repository.fetch(
           page: currentPage,
           searchText: searchText.isEmpty ? nil : searchText,
-          sortOrder: sortOrder
+          sortOrder: sortOrder,
+          track: track
         )
         hasNextPage = response.hasNextPage
-        proposals = .loaded(response.docs.map { $0.toSwiftEvolution() })
+        proposals = .loaded(response.docs.map { $0.toSwiftEvolution(track: track) })
         currentPage += 1
       } catch {
         proposals = .error(error)
@@ -275,10 +292,10 @@ struct ProposalListScreen: View {
 
     do {
       // 全提案のスコアを取得
-      let allScores = await quizRepository.getAllScores()
+      let allScores = await activeQuizRepository.getAllScores()
 
       // 全提案のクイズ数を取得
-      let allQuizCounts = try await quizRepository.getAllQuizCounts()
+      let allQuizCounts = try await activeQuizRepository.getAllQuizCounts()
 
       // ProposalProgressマップを生成
       var progresses: [String: ProposalProgress] = [:]
@@ -306,7 +323,7 @@ struct ProposalListScreen: View {
   /// 今日のチャレンジ対象の提案を決定論的に選び、内容を読み込む
   private func loadDailyChallenge() async {
     do {
-      let counts = try await quizRepository.getAllQuizCounts()
+      let counts = try await activeQuizRepository.getAllQuizCounts()
       let service = DailyChallengeService()
       guard
         let proposalId = service.todaysProposalId(from: Array(counts.keys), date: Date())

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -113,15 +113,18 @@ struct ProposalQuizView: View {
       .navigationBarTitleDisplayMode(.inline)
     #endif
     .toolbar {
-      ToolbarItem(placement: .primaryAction) {
-        NavigationLink(
-          value: DependencyGraphRoute(
-            rootProposalId: proposal.proposalId,
-            rootTitle: proposal.title
-          )
-        ) {
-          Image(systemName: "point.3.connected.trianglepath.dotted")
-            .accessibilityLabel("依存グラフ")
+      // 依存グラフは Swift Evolution のみ（ST は v1 では対象外）
+      if proposal.track == .swiftEvolution {
+        ToolbarItem(placement: .primaryAction) {
+          NavigationLink(
+            value: DependencyGraphRoute(
+              rootProposalId: proposal.proposalId,
+              rootTitle: proposal.title
+            )
+          ) {
+            Image(systemName: "point.3.connected.trianglepath.dotted")
+              .accessibilityLabel("依存グラフ")
+          }
         }
       }
       ToolbarItem(placement: .primaryAction) {
@@ -191,6 +194,8 @@ struct ProposalQuizView: View {
 
   /// この提案が参照している（理解の前提となる）提案を読み込む
   private func loadRelatedProposals() async {
+    // 参照（依存）は Swift Evolution のみ。ST は別トラックで bare ID が衝突するため読み込まない。
+    guard proposal.track == .swiftEvolution else { return }
     do {
       let edges = try await referenceRepository.fetchOutgoing(fromProposalIds: [proposal.proposalId])
       let ids = Array(Set(edges.map(\.toProposalId))).sorted()

--- a/ios/se-masked-quiz/Repositories/QuizRepository.swift
+++ b/ios/se-masked-quiz/Repositories/QuizRepository.swift
@@ -58,18 +58,22 @@ protocol QuizRepository: Actor, Sendable {
 
 actor QuizRepositoryImpl: QuizRepository {
   private let userDefaults: UserDefaults
+  private let track: ProposalTrack
 
   // MARK: - Cache
   private var answersCache: [String: [QuizAnswer]]?
   private var answersCacheTimestamp: Date?
   private let cacheExpirationInterval: TimeInterval = 43200  // 12時間
 
-  private static let scoreKey = "proposal_scores"
-  private static let llmQuizzesKey = "llm_quizzes"
-  private static let llmQuizScoresKey = "llm_quiz_scores"
+  // SE は従来キー（"proposal_scores" 等）、ST は名前空間で分離（"testing_proposal_scores"）。
+  // bare 4桁 proposalId が SE/ST で衝突するため、ローカル進捗もトラックで分ける必要がある。
+  private var scoreKey: String { "\(track.storageNamespace)proposal_scores" }
+  private var llmQuizzesKey: String { "\(track.storageNamespace)llm_quizzes" }
+  private var llmQuizScoresKey: String { "\(track.storageNamespace)llm_quiz_scores" }
 
-  init(userDefaults: UserDefaults = .standard) {
+  init(userDefaults: UserDefaults = .standard, track: ProposalTrack = .swiftEvolution) {
     self.userDefaults = userDefaults
+    self.track = track
   }
 
   // MARK: - Mask Quiz Score Management
@@ -79,12 +83,12 @@ actor QuizRepositoryImpl: QuizRepository {
     scores[score.proposalId] = score
 
     if let encoded = try? JSONEncoder().encode(scores) {
-      userDefaults.set(encoded, forKey: Self.scoreKey)
+      userDefaults.set(encoded, forKey: scoreKey)
     }
   }
 
   func getAllScores() async -> [String: ProposalScore] {
-    guard let data = userDefaults.data(forKey: Self.scoreKey),
+    guard let data = userDefaults.data(forKey: scoreKey),
       let scores = try? JSONDecoder().decode([String: ProposalScore].self, from: data)
     else {
       return [:]
@@ -123,7 +127,7 @@ actor QuizRepositoryImpl: QuizRepository {
     scores.removeValue(forKey: proposalId)
 
     if let encoded = try? JSONEncoder().encode(scores) {
-      userDefaults.set(encoded, forKey: Self.scoreKey)
+      userDefaults.set(encoded, forKey: scoreKey)
     }
   }
 
@@ -139,7 +143,7 @@ actor QuizRepositoryImpl: QuizRepository {
     allLLMQuizzes[proposalId] = quizzes
 
     if let encoded = try? JSONEncoder().encode(allLLMQuizzes) {
-      userDefaults.set(encoded, forKey: Self.llmQuizzesKey)
+      userDefaults.set(encoded, forKey: llmQuizzesKey)
     }
   }
 
@@ -158,7 +162,7 @@ actor QuizRepositoryImpl: QuizRepository {
     allLLMQuizzes.removeValue(forKey: proposalId)
 
     if let encoded = try? JSONEncoder().encode(allLLMQuizzes) {
-      userDefaults.set(encoded, forKey: Self.llmQuizzesKey)
+      userDefaults.set(encoded, forKey: llmQuizzesKey)
     }
 
     // スコアも削除
@@ -172,7 +176,7 @@ actor QuizRepositoryImpl: QuizRepository {
     scores[score.proposalId] = score
 
     if let encoded = try? JSONEncoder().encode(scores) {
-      userDefaults.set(encoded, forKey: Self.llmQuizScoresKey)
+      userDefaults.set(encoded, forKey: llmQuizScoresKey)
     }
   }
 
@@ -186,7 +190,7 @@ actor QuizRepositoryImpl: QuizRepository {
     scores.removeValue(forKey: proposalId)
 
     if let encoded = try? JSONEncoder().encode(scores) {
-      userDefaults.set(encoded, forKey: Self.llmQuizScoresKey)
+      userDefaults.set(encoded, forKey: llmQuizScoresKey)
     }
   }
 
@@ -201,7 +205,7 @@ actor QuizRepositoryImpl: QuizRepository {
     }
 
     let baseURL = Env.serverBaseURL.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-    guard let url = URL(string: "\(baseURL)/api/quiz-answers?limit=1000") else {
+    guard let url = URL(string: "\(baseURL)/api/\(track.quizAnswersSlug)?limit=1000") else {
       throw QuizError.invalidResponse
     }
 
@@ -229,7 +233,7 @@ actor QuizRepositoryImpl: QuizRepository {
   }
 
   private func getAllLLMQuizzes() async -> [String: [LLMQuiz]] {
-    guard let data = userDefaults.data(forKey: Self.llmQuizzesKey),
+    guard let data = userDefaults.data(forKey: llmQuizzesKey),
       let quizzes = try? JSONDecoder().decode([String: [LLMQuiz]].self, from: data)
     else {
       return [:]
@@ -238,7 +242,7 @@ actor QuizRepositoryImpl: QuizRepository {
   }
 
   private func getAllLLMQuizScores() async -> [String: LLMQuizScore] {
-    guard let data = userDefaults.data(forKey: Self.llmQuizScoresKey),
+    guard let data = userDefaults.data(forKey: llmQuizScoresKey),
       let scores = try? JSONDecoder().decode([String: LLMQuizScore].self, from: data)
     else {
       return [:]
@@ -281,6 +285,21 @@ extension EnvironmentValues {
   var quizRepository: any QuizRepository {
     get { self[QuizRepositoryImpl.self] }
     set { self[QuizRepositoryImpl.self] = newValue }
+  }
+}
+
+// Swift Testing トラック用のクイズリポジトリ（testing-quiz-answers エンドポイント、
+// ローカル保存も "testing_" 名前空間）。SE 用とは別インスタンスで分離する。
+private struct TestingQuizRepositoryKey: EnvironmentKey {
+  static var defaultValue: any QuizRepository {
+    QuizRepositoryImpl(track: .swiftTesting)
+  }
+}
+
+extension EnvironmentValues {
+  var testingQuizRepository: any QuizRepository {
+    get { self[TestingQuizRepositoryKey.self] }
+    set { self[TestingQuizRepositoryKey.self] = newValue }
   }
 }
 

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -48,7 +48,8 @@ struct SERepository: Sendable {
   func fetch(
     page: Int,
     searchText: String? = nil,
-    sortOrder: ProposalSortOrder = .descending
+    sortOrder: ProposalSortOrder = .descending,
+    track: ProposalTrack = .swiftEvolution
   ) async throws -> PayloadListResponse<PayloadProposal> {
     let baseURL = Env.serverBaseURL
     let apiKey = Env.serverApiKey
@@ -57,7 +58,8 @@ struct SERepository: Sendable {
       page: page,
       limit: Self.pageSize,
       searchText: searchText,
-      sortOrder: sortOrder
+      sortOrder: sortOrder,
+      track: track
     )
     var request = URLRequest(url: requestURL)
     request.httpMethod = "GET"
@@ -107,14 +109,17 @@ struct SERepository: Sendable {
   }
 
   /// 提案IDを指定して単一の提案を取得する（デイリーチャレンジ用）
-  func fetchProposal(byProposalId proposalId: String) async throws -> SwiftEvolution? {
+  func fetchProposal(
+    byProposalId proposalId: String,
+    track: ProposalTrack = .swiftEvolution
+  ) async throws -> SwiftEvolution? {
     let baseURL = Env.serverBaseURL
     let apiKey = Env.serverApiKey
     var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     while trimmed.hasSuffix("/") {
       trimmed.removeLast()
     }
-    guard var components = URLComponents(string: "\(trimmed)/api/proposals") else {
+    guard var components = URLComponents(string: "\(trimmed)/api/\(track.proposalsSlug)") else {
       throw SERepositoryError.invalidBaseURL
     }
     components.queryItems = [
@@ -136,7 +141,7 @@ struct SERepository: Sendable {
       throw SERepositoryError.httpStatus(http.statusCode)
     }
     let decoded = try JSONDecoder().decode(PayloadListResponse<PayloadProposal>.self, from: data)
-    return decoded.docs.first?.toSwiftEvolution()
+    return decoded.docs.first?.toSwiftEvolution(track: track)
   }
 
   static func proposalsURL(
@@ -144,13 +149,14 @@ struct SERepository: Sendable {
     page: Int,
     limit: Int,
     searchText: String? = nil,
-    sortOrder: ProposalSortOrder = .descending
+    sortOrder: ProposalSortOrder = .descending,
+    track: ProposalTrack = .swiftEvolution
   ) throws -> URL {
     var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
     while trimmed.hasSuffix("/") {
       trimmed.removeLast()
     }
-    guard var components = URLComponents(string: "\(trimmed)/api/proposals") else {
+    guard var components = URLComponents(string: "\(trimmed)/api/\(track.proposalsSlug)") else {
       throw SERepositoryError.invalidBaseURL
     }
     var items: [URLQueryItem] = [
@@ -279,7 +285,7 @@ struct PayloadProposal: Decodable, Sendable {
   let reviewManager: String?
   let status: String?
 
-  func toSwiftEvolution() -> SwiftEvolution {
+  func toSwiftEvolution(track: ProposalTrack = .swiftEvolution) -> SwiftEvolution {
     SwiftEvolution(
       id: String(id),
       proposalId: proposalId,
@@ -287,7 +293,8 @@ struct PayloadProposal: Decodable, Sendable {
       reviewManager: reviewManager,
       status: status,
       authors: authors,
-      content: content
+      content: content,
+      track: track
     )
   }
 }

--- a/ios/se-masked-quiz/se_masked_quizApp.swift
+++ b/ios/se-masked-quiz/se_masked_quizApp.swift
@@ -17,9 +17,18 @@ struct se_masked_quizApp: App {
 
   var body: some Scene {
     WindowGroup {
-      ProposalListScreen()
-        .environment(\.analytics, analytics)
-        .environment(\.streakRepository, streakRepository)
+      TabView {
+        ProposalListScreen(track: .swiftEvolution)
+          .tabItem {
+            Label("Swift Evolution", systemImage: "swift")
+          }
+        ProposalListScreen(track: .swiftTesting)
+          .tabItem {
+            Label("Swift Testing", systemImage: "checkmark.seal")
+          }
+      }
+      .environment(\.analytics, analytics)
+      .environment(\.streakRepository, streakRepository)
     }
     .onChange(of: scenePhase) { _, newPhase in
       guard newPhase == .active else { return }

--- a/server/migrations/0003_testing_collections.sql
+++ b/server/migrations/0003_testing_collections.sql
@@ -1,0 +1,31 @@
+CREATE TABLE `testing_proposals` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `proposal_id` text NOT NULL,
+  `title` text NOT NULL,
+  `authors` text NOT NULL,
+  `content` text NOT NULL,
+  `review_manager` text,
+  `status` text,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+CREATE UNIQUE INDEX `testing_proposals_proposal_id_idx` ON `testing_proposals` (`proposal_id`);
+CREATE INDEX `testing_proposals_updated_at_idx` ON `testing_proposals` (`updated_at`);
+CREATE INDEX `testing_proposals_created_at_idx` ON `testing_proposals` (`created_at`);
+
+CREATE TABLE `testing_quiz_answers` (
+  `id` integer PRIMARY KEY NOT NULL,
+  `proposal_id` text NOT NULL,
+  `answers` text NOT NULL,
+  `updated_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL,
+  `created_at` text DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')) NOT NULL
+);
+CREATE UNIQUE INDEX `testing_quiz_answers_proposal_id_idx` ON `testing_quiz_answers` (`proposal_id`);
+CREATE INDEX `testing_quiz_answers_updated_at_idx` ON `testing_quiz_answers` (`updated_at`);
+CREATE INDEX `testing_quiz_answers_created_at_idx` ON `testing_quiz_answers` (`created_at`);
+
+-- Payload's locked-documents join table needs a column per collection.
+ALTER TABLE `payload_locked_documents_rels` ADD COLUMN `testing_proposals_id` integer REFERENCES `testing_proposals`(`id`);
+ALTER TABLE `payload_locked_documents_rels` ADD COLUMN `testing_quiz_answers_id` integer REFERENCES `testing_quiz_answers`(`id`);
+CREATE INDEX `payload_locked_documents_rels_testing_proposals_id_idx` ON `payload_locked_documents_rels` (`testing_proposals_id`);
+CREATE INDEX `payload_locked_documents_rels_testing_quiz_answers_id_idx` ON `payload_locked_documents_rels` (`testing_quiz_answers_id`);

--- a/server/src/collections/TestingProposals.ts
+++ b/server/src/collections/TestingProposals.ts
@@ -1,0 +1,63 @@
+import type { CollectionConfig } from 'payload';
+
+const PROPOSAL_ID_PATTERN = /^\d{4}$/;
+
+// Swift Testing (ST) proposals. Stored in a separate collection/table from the
+// Swift Evolution `proposals` so the 4-digit id namespaces don't collide and the
+// existing SE endpoints stay byte-for-byte unchanged (backward compatible).
+// The `ST-` prefix is presentation-only; ids are stored bare here.
+export const TestingProposals: CollectionConfig = {
+	slug: 'testing-proposals',
+	admin: {
+		useAsTitle: 'title',
+	},
+	access: {
+		read: () => true,
+		create: ({ req }) => !!req.user,
+		update: ({ req }) => !!req.user,
+		delete: ({ req }) => !!req.user,
+	},
+	fields: [
+		{
+			name: 'proposalId',
+			type: 'text',
+			required: true,
+			unique: true,
+			index: true,
+			validate: (value: unknown) => {
+				if (typeof value !== 'string' || !PROPOSAL_ID_PATTERN.test(value)) {
+					return 'proposalId must be four digits (e.g. 0001)';
+				}
+				return true;
+			},
+		},
+		{
+			name: 'title',
+			type: 'text',
+			required: true,
+			maxLength: 500,
+		},
+		{
+			name: 'authors',
+			type: 'text',
+			required: true,
+			maxLength: 1000,
+		},
+		{
+			name: 'content',
+			type: 'textarea',
+			required: true,
+			maxLength: 500_000,
+		},
+		{
+			name: 'reviewManager',
+			type: 'text',
+			maxLength: 200,
+		},
+		{
+			name: 'status',
+			type: 'text',
+			maxLength: 500,
+		},
+	],
+};

--- a/server/src/collections/TestingQuizAnswers.ts
+++ b/server/src/collections/TestingQuizAnswers.ts
@@ -1,0 +1,69 @@
+import type { CollectionConfig } from 'payload';
+
+const PROPOSAL_ID_PATTERN = /^\d{4}$/;
+const MAX_ANSWERS = 1000;
+const MAX_OPTIONS_PER_ANSWER = 50;
+const MAX_STRING_LENGTH = 2000;
+
+const isQuizAnswerShape = (entry: unknown): entry is Record<string, unknown> => {
+	if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return false;
+	const record = entry as Record<string, unknown>;
+	if (typeof record.index !== 'number' || !Number.isInteger(record.index) || record.index < 0) {
+		return false;
+	}
+	if (typeof record.answer !== 'string' || record.answer.length > MAX_STRING_LENGTH) {
+		return false;
+	}
+	if (!Array.isArray(record.options) || record.options.length > MAX_OPTIONS_PER_ANSWER) {
+		return false;
+	}
+	return record.options.every((option) => typeof option === 'string' && option.length <= MAX_STRING_LENGTH);
+};
+
+// Quiz answers for Swift Testing (ST) proposals. Separate collection/table from
+// the Swift Evolution `quiz-answers` to keep the 4-digit id namespaces disjoint
+// and leave the existing SE endpoint unchanged.
+export const TestingQuizAnswers: CollectionConfig = {
+	slug: 'testing-quiz-answers',
+	admin: {
+		useAsTitle: 'proposalId',
+	},
+	access: {
+		read: () => true,
+		create: ({ req }) => !!req.user,
+		update: ({ req }) => !!req.user,
+		delete: ({ req }) => !!req.user,
+	},
+	fields: [
+		{
+			name: 'proposalId',
+			type: 'text',
+			required: true,
+			unique: true,
+			index: true,
+			validate: (value: unknown) => {
+				if (typeof value !== 'string' || !PROPOSAL_ID_PATTERN.test(value)) {
+					return 'proposalId must be four digits (e.g. 0001)';
+				}
+				return true;
+			},
+		},
+		{
+			name: 'answers',
+			type: 'json',
+			required: true,
+			validate: (value: unknown) => {
+				if (!Array.isArray(value)) {
+					return 'answers must be an array of QuizAnswer objects';
+				}
+				if (value.length > MAX_ANSWERS) {
+					return `answers must contain at most ${MAX_ANSWERS} entries`;
+				}
+				if (!value.every(isQuizAnswerShape)) {
+					return 'each answer must have { index: integer, answer: string, options: string[] }';
+				}
+				return true;
+			},
+		},
+	],
+};

--- a/server/src/payload.config.ts
+++ b/server/src/payload.config.ts
@@ -11,6 +11,8 @@ import type { GetPlatformProxyOptions } from 'wrangler';
 import { Proposals } from './collections/Proposals';
 import { ProposalReferences } from './collections/ProposalReferences';
 import { QuizAnswers } from './collections/QuizAnswers';
+import { TestingProposals } from './collections/TestingProposals';
+import { TestingQuizAnswers } from './collections/TestingQuizAnswers';
 import { Users } from './collections/Users';
 
 const filename = fileURLToPath(import.meta.url);
@@ -69,7 +71,7 @@ export default buildConfig({
 		binding: cloudflare.env.DB,
 	}),
 	editor: lexicalEditor(),
-	collections: [Users, Proposals, QuizAnswers, ProposalReferences],
+	collections: [Users, Proposals, QuizAnswers, ProposalReferences, TestingProposals, TestingQuizAnswers],
 	logger: isProduction ? cloudflareLogger : undefined,
 	// iOS app is the only client; browsers must not be able to call this API.
 	cors: [],

--- a/server/test/index.spec.ts
+++ b/server/test/index.spec.ts
@@ -52,4 +52,32 @@ describe('Payload CMS Configuration', () => {
 		expect(typeof field.validate('12')).toBe('string');
 		expect(typeof field.validate(1234)).toBe('string');
 	});
+
+	it('TestingProposals collection has required fields', async () => {
+		const { TestingProposals } = await import('../src/collections/TestingProposals');
+		expect(TestingProposals.slug).toBe('testing-proposals');
+		const fieldNames = TestingProposals.fields.map((f) => ('name' in f ? f.name : ''));
+		expect(fieldNames).toContain('proposalId');
+		expect(fieldNames).toContain('title');
+		expect(fieldNames).toContain('content');
+	});
+
+	it('TestingQuizAnswers collection has required fields', async () => {
+		const { TestingQuizAnswers } = await import('../src/collections/TestingQuizAnswers');
+		expect(TestingQuizAnswers.slug).toBe('testing-quiz-answers');
+		const fieldNames = TestingQuizAnswers.fields.map((f) => ('name' in f ? f.name : ''));
+		expect(fieldNames).toContain('proposalId');
+		expect(fieldNames).toContain('answers');
+	});
+
+	it('TestingProposals stores bare four-digit ids (prefix is display-only)', async () => {
+		const { TestingProposals } = await import('../src/collections/TestingProposals');
+		const field = TestingProposals.fields.find((f) => 'name' in f && f.name === 'proposalId') as {
+			validate: (value: unknown) => true | string;
+		};
+		expect(field.validate('0001')).toBe(true);
+		// ST- prefix is presentation-only; ids are stored bare, so a prefixed id is invalid here
+		expect(typeof field.validate('ST-0001')).toBe('string');
+		expect(typeof field.validate('12')).toBe('string');
+	});
 });


### PR DESCRIPTION
## 概要
Issue #20。Swift Testing(ST) 提案をアプリに取り込む。**既存テーブルを一切変えず**、ST 用コレクションを追加（後方互換維持・移行なし）。本 PR は backend(Phase A) と iOS(Phase C)。pipeline(Phase B) は別リポジトリ: fummicc1/swift-evolution-masking#10。

## 設計
- Payload コレクション=テーブル。既存 `proposals`/`quiz-answers`/`proposal-references` は**無改変**。
- ST 用に `testing-proposals` / `testing-quiz-answers` を追加。proposalId は各テーブルで **bare 4桁**（衝突回避）。`SE-`/`ST-` 接頭辞は**表示専用**。
- → 旧アプリ(1.4.0)に影響ゼロ、backend を先に出せる。

## Phase A（backend）
- `TestingProposals` / `TestingQuizAnswers` コレクション（既存同型・bare 検証）
- `0003_testing_collections.sql`（新テーブル + `payload_locked_documents_rels` 対応列）
- vitest テスト追加

## Phase C（iOS）
- `ProposalTrack`(SE/ST)・`SwiftEvolution.track`/`displayId`
- `SERepository` / `QuizRepositoryImpl` を track 対応（エンドポイント・ローカル保存を分離）
- ルートを **TabView(SE/ST)** に、一覧はトラック分離
- 表示IDを `SE-xxxx`/`ST-xxxx` に（`Int` 変換・`"SE-"` ハードコード撤去）
- 依存グラフ・前提提案は SE のみ（ST は bare ID 衝突回避のため除外）

## 検証
- backend: `0003` ローカル適用→PRAGMA確認、`payload generate:types` で Testing 型生成
- iOS: `xcodebuild` ビルド成功、ユニットテスト **93 passed / 0 failed**

## デプロイ順序
A(backendデプロイ + `0003` remote 適用) → B(pipeline 投入) → C(iOS リリース)。順序制約は緩い（既存無改変のため）。

Closes #20

https://claude.ai/code/session_01SHQCTyWAUTRXiHe4Dxyvcf