### PR TITLE
chore(ios): fastlane に release_testflight レーンを追加

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -48,6 +48,27 @@ platform :ios do
     )
   end
 
+  desc "Build and upload a new build to TestFlight"
+  lane :release_testflight do
+    build_app(
+      project: "se-masked-quiz.xcodeproj",
+      scheme: "se-masked-quiz",
+      destination: "generic/platform=iOS",
+      export_method: "app-store",
+      export_options: {
+        method: "app-store",
+        teamID: "S8WBNKMKYU",
+        signingStyle: "automatic"
+      },
+      xcargs: "-allowProvisioningUpdates"
+    )
+
+    upload_to_testflight(
+      app_identifier: ENV["APP_IDENTIFIER"],
+      skip_waiting_for_build_processing: true
+    )
+  end
+
   desc "Preview the local release notes to be uploaded (no network, no auth)"
   lane :preview_metadata do
     %w[ja en-US].each do |locale|

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -39,13 +39,21 @@ Upload metadata only (no screenshots)
 
 Download existing metadata from App Store Connect
 
+### ios release_testflight
+
+```sh
+[bundle exec] fastlane ios release_testflight
+```
+
+Build and upload a new build to TestFlight
+
 ### ios preview_metadata
 
 ```sh
 [bundle exec] fastlane ios preview_metadata
 ```
 
-Verify metadata before upload (dry run, no upload)
+Preview the local release notes to be uploaded (no network, no auth)
 
 ----
 


### PR DESCRIPTION
## Summary
- `release_testflight` レーン(build_app + upload_to_testflight)を追加。1.5.0(build 6)のTestFlightアップロードに実際に使用し、成功を確認済み
- multiplatform ターゲットのため `destination: generic/platform=iOS` を明示（省略するとgymがmacOS向けにアーカイブしてしまう）
- `export_options` を明示指定（gymの自動検出が `-showBuildSettings` のタイムアウトで無言でipaエクスポートをスキップしていたため）

## Test plan
- [x] 上記レーンで実際に 1.5.0 (build 6) を TestFlight にアップロード済み（App Store Connect 上で確認可能）

https://claude.ai/code/session_018797Aw3Jz6YMixqg7eYa7y