### PR TITLE
chore(ios): fastlane に submit_for_review レーンを追加

### DIFF
--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -69,6 +69,26 @@ platform :ios do
     )
   end
 
+  desc "Submit the already-uploaded build for App Store review"
+  lane :submit_for_review do
+    deliver(
+      app_identifier: ENV["APP_IDENTIFIER"],
+      app_version: "1.5.0",
+      build_number: "6",
+      skip_screenshots: true,
+      skip_binary_upload: true,
+      skip_app_version_update: false,
+      force: true,
+      run_precheck_before_submit: false,
+      submit_for_review: true,
+      automatic_release: false,
+      submission_information: {
+        export_compliance_uses_encryption: false,
+        add_id_info_uses_idfa: false
+      }
+    )
+  end
+
   desc "Preview the local release notes to be uploaded (no network, no auth)"
   lane :preview_metadata do
     %w[ja en-US].each do |locale|

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -47,6 +47,14 @@ Download existing metadata from App Store Connect
 
 Build and upload a new build to TestFlight
 
+### ios submit_for_review
+
+```sh
+[bundle exec] fastlane ios submit_for_review
+```
+
+Submit the already-uploaded build for App Store review
+
 ### ios preview_metadata
 
 ```sh


### PR DESCRIPTION
## Summary
- `submit_for_review` レーン(deliver + submit_for_review: true)を追加。1.5.0(build 6)のApp Store審査提出に実際に使用し、成功を確認済み（"Successfully submitted the app for review!"）
- `skip_app_version_update: false` が必須（アプリは既に1.4.0でLive状態のため、1.5.0の新バージョンレコードをApp Store Connect上に作成してからビルドを紐付ける必要がある）
- 輸出規制申告: `export_compliance_uses_encryption: false`（HTTPS以外の独自暗号化なし）
- リリース方式: `automatic_release: false`（審査承認後は手動リリース）

## Test plan
- [x] 上記レーンで実際に 1.5.0 (build 6) を App Store 審査に提出済み（App Store Connect 上で "Waiting for Review" 状態を確認可能）

https://claude.ai/code/session_018797Aw3Jz6YMixqg7eYa7y