### PR TITLE
chore(ios): swift-complexity CIゲート導入 + しきい値超過2件を修正

### DIFF
--- a/.github/workflows/ios-complexity.yml
+++ b/.github/workflows/ios-complexity.yml
@@ -1,0 +1,18 @@
+name: iOS Code Complexity
+
+on:
+  pull_request:
+    paths:
+      - "ios/se-masked-quiz/**/*.swift"
+
+jobs:
+  complexity:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install swift-complexity
+        run: brew install fummicc1/tap/swift-complexity
+
+      - name: Check code complexity
+        run: swift-complexity ios/se-masked-quiz --recursive --threshold 10

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -47,45 +47,16 @@ struct ProposalListScreen: View {
       // 詳細画面でクイズに回答して戻ってきたとき（path が縮む）に進捗を再読込し、
       // 一覧の進捗率・正解率を最新化する
       .onChange(of: navigationPath.count) { oldCount, newCount in
-        if newCount < oldCount {
-          Task { await loadQuizProgresses() }
-        }
+        handleNavigationPathChange(oldCount: oldCount, newCount: newCount)
       }
       .sheet(isPresented: $showsSetting) {
         SettingScreen()
       }
-      .onChange(
-        of: shouldLoadNextPage,
-        { oldValue, newValue in
-          if !oldValue, newValue {
-            if proposals.isLoading || !hasNextPage {
-              return
-            }
-            proposals.startLoading()
-            Task {
-              do {
-                let response = try await repository.fetch(
-                  page: currentPage,
-                  searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText,
-                  sortOrder: sortOrder,
-                  track: track
-                )
-                hasNextPage = response.hasNextPage
-                var currentProposals = proposals.content
-                currentProposals.append(contentsOf: response.docs.map { $0.toSwiftEvolution(track: track) })
-                proposals = .loaded(currentProposals)
-                currentPage += 1
-              } catch {
-                proposals = .error(error)
-              }
-            }
-          }
-        }
-      )
+      .onChange(of: shouldLoadNextPage) { oldValue, newValue in
+        Task { await loadNextPageIfNeeded(oldValue: oldValue, newValue: newValue) }
+      }
       .task(id: searchText) {
-        try? await Task.sleep(for: .milliseconds(300))
-        guard !Task.isCancelled else { return }
-        debouncedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        await debounceSearchText()
       }
       .onChange(of: debouncedSearchText) { _, newValue in
         reloadFromFirstPage(searchText: newValue, sortOrder: sortOrder)
@@ -94,67 +65,103 @@ struct ProposalListScreen: View {
         reloadFromFirstPage(searchText: debouncedSearchText, sortOrder: newValue)
       }
       .task {
-        if !proposals.content.isEmpty || proposals.isLoading {
-          return
-        }
-        do {
-          proposals.startLoading()
-          let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder, track: track)
-          hasNextPage = response.hasNextPage
-          self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution(track: track) })
-          currentPage += 1
-
-          // 進捗情報を読み込む
-          await loadQuizProgresses()
-
-          // 今日のチャレンジを読み込む（Swift Evolution タブのみ）
-          if track == .swiftEvolution {
-            await loadDailyChallenge()
-          }
-        } catch {
-          self.proposals = .error(error)
-        }
+        await loadInitialProposalsIfNeeded()
       }
-      #if os(iOS)
-        .sheet(
-          item: $modalWebUrl,
-          content: { url in
-            DefaultWebView(
-              htmlContent: .url(url),
-              onNavigate: { modalWebUrl = $0 },
-              onMaskedWordTap: { _ in
-              },
-              isCorrect: .constant([:]),
-              answers: .constant([:])
-            )
-          })
-      #else
-        .sheet(item: $modalWebUrl) { url in
-          VStack(spacing: 0) {
-            HStack {
-              Text(url.absoluteString)
-              Spacer()
-              Button("Close") {
-                modalWebUrl = nil
-              }
-            }
-            .padding(8)
-            DefaultWebView(
-              htmlContent: .url(url),
-              onNavigate: { modalWebUrl = $0 },
-              onMaskedWordTap: { _ in
-              },
-              isCorrect: .constant([:]),
-              answers: .constant([:])
-            )
-            .frame(
-              width: proxy.size.width * 0.8,
-              height: proxy.size.height * 0.8
-            )
+      .sheet(item: $modalWebUrl) { url in
+        webPreviewSheet(url: url, proxy: proxy)
+      }
+    }
+  }
+
+  // MARK: - Body Helpers
+
+  private func handleNavigationPathChange(oldCount: Int, newCount: Int) {
+    guard newCount < oldCount else { return }
+    Task { await loadQuizProgresses() }
+  }
+
+  private func debounceSearchText() async {
+    try? await Task.sleep(for: .milliseconds(300))
+    guard !Task.isCancelled else { return }
+    debouncedSearchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func loadNextPageIfNeeded(oldValue: Bool, newValue: Bool) async {
+    guard !oldValue, newValue, !proposals.isLoading, hasNextPage else { return }
+    proposals.startLoading()
+    do {
+      let response = try await repository.fetch(
+        page: currentPage,
+        searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText,
+        sortOrder: sortOrder,
+        track: track
+      )
+      hasNextPage = response.hasNextPage
+      var currentProposals = proposals.content
+      currentProposals.append(contentsOf: response.docs.map { $0.toSwiftEvolution(track: track) })
+      proposals = .loaded(currentProposals)
+      currentPage += 1
+    } catch {
+      proposals = .error(error)
+    }
+  }
+
+  private func loadInitialProposalsIfNeeded() async {
+    guard proposals.content.isEmpty, !proposals.isLoading else { return }
+    do {
+      proposals.startLoading()
+      let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder, track: track)
+      hasNextPage = response.hasNextPage
+      self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution(track: track) })
+      currentPage += 1
+
+      // 進捗情報を読み込む
+      await loadQuizProgresses()
+
+      // 今日のチャレンジを読み込む（Swift Evolution タブのみ）
+      if track == .swiftEvolution {
+        await loadDailyChallenge()
+      }
+    } catch {
+      self.proposals = .error(error)
+    }
+  }
+
+  @ViewBuilder
+  private func webPreviewSheet(url: URL, proxy: GeometryProxy) -> some View {
+    #if os(iOS)
+      DefaultWebView(
+        htmlContent: .url(url),
+        onNavigate: { modalWebUrl = $0 },
+        onMaskedWordTap: { _ in
+        },
+        isCorrect: .constant([:]),
+        answers: .constant([:])
+      )
+    #else
+      VStack(spacing: 0) {
+        HStack {
+          Text(url.absoluteString)
+          Spacer()
+          Button("Close") {
+            modalWebUrl = nil
           }
         }
-      #endif
-    }
+        .padding(8)
+        DefaultWebView(
+          htmlContent: .url(url),
+          onNavigate: { modalWebUrl = $0 },
+          onMaskedWordTap: { _ in
+          },
+          isCorrect: .constant([:]),
+          answers: .constant([:])
+        )
+        .frame(
+          width: proxy.size.width * 0.8,
+          height: proxy.size.height * 0.8
+        )
+      }
+    #endif
   }
 
   // MARK: - Subviews

--- a/ios/se-masked-quiz/Services/LLMService.swift
+++ b/ios/se-masked-quiz/Services/LLMService.swift
@@ -393,6 +393,10 @@ enum LLMServiceError: Error, LocalizedError {
   case mlxUnavailable
 
   var errorDescription: String? {
+    modelErrorDescription ?? downloadErrorDescription
+  }
+
+  private var modelErrorDescription: String? {
     switch self {
     case .modelNotLoaded:
       return "モデルが読み込まれていません。先にloadModel()を呼び出してください。"
@@ -404,6 +408,13 @@ enum LLMServiceError: Error, LocalizedError {
       return "クイズ生成に失敗しました: \(message)"
     case .mlxError(let error):
       return "MLXエラー: \(error.localizedDescription)"
+    default:
+      return nil
+    }
+  }
+
+  private var downloadErrorDescription: String? {
+    switch self {
     case .insufficientStorage(let required, let available):
       let requiredGB = Double(required) / 1_000_000_000
       let availableGB = Double(available) / 1_000_000_000
@@ -416,6 +427,8 @@ enum LLMServiceError: Error, LocalizedError {
       return "ファイルシステムエラー: \(error.localizedDescription)"
     case .mlxUnavailable:
       return "このデバイスではMLXが利用できません"
+    default:
+      return nil
     }
   }
 }


### PR DESCRIPTION
## Summary
- [fummicc1/swift-complexity](https://github.com/fummicc1/swift-complexity) をPR時のCIゲートとして導入(`.github/workflows/ios-complexity.yml`)。しきい値10でCyclomatic/Cognitive Complexityをチェックし、超過時はPRを失敗させる
- 導入前にローカルで実行したところ既存コードで2件のしきい値超過(共に11)が見つかったため、ゲートが最初からグリーンになるようリファクタリング:
  - `ProposalListScreen.body` (11→1): `.onChange`/`.task` の各クロージャの中身をprivateメソッドに切り出し、プラットフォーム分岐のWebプレビューシートを`@ViewBuilder`関数に分離
  - `LLMServiceError.errorDescription` (11→1): 10ケースのswitchを5ケースずつの2つのswitch(`modelErrorDescription`/`downloadErrorDescription`)に分割

## Test plan
- [x] `xcodebuild build` 成功
- [x] `xcodebuild test -only-testing:se-masked-quizTests` 全件成功
- [x] `swift-complexity ios/se-masked-quiz --recursive --threshold 10` がexit code 0(修正前は2件の超過でexit code 1)
- [x] 動作変更なし(ロジックはそのまま、構造のみ変更)

https://claude.ai/code/session_018797Aw3Jz6YMixqg7eYa7y