### PR TITLE
通知DeepLink連携とストリーク統計画面を追加

### DIFF
--- a/ios/se-masked-quiz.xcodeproj/project.pbxproj
+++ b/ios/se-masked-quiz.xcodeproj/project.pbxproj
@@ -34,9 +34,22 @@
 		D3921FF92D252F0C008C3732 /* se-masked-quizUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "se-masked-quizUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		D3EE00000000000000000001 /* Exceptions for "se-masked-quiz" folder in "se-masked-quiz" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = D3921FDD2D252F0A008C3732 /* se-masked-quiz */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		D3921FE02D252F0A008C3732 /* se-masked-quiz */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				D3EE00000000000000000001 /* Exceptions for "se-masked-quiz" folder in "se-masked-quiz" target */,
+			);
 			path = "se-masked-quiz";
 			sourceTree = "<group>";
 		};
@@ -415,18 +428,8 @@
 				DEVELOPMENT_TEAM = S8WBNKMKYU;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "se-masked-quiz/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
@@ -456,18 +459,8 @@
 				DEVELOPMENT_TEAM = S8WBNKMKYU;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphoneos*]" = YES;
-				"INFOPLIST_KEY_UILaunchScreen_Generation[sdk=iphonesimulator*]" = YES;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphoneos*]" = UIStatusBarStyleDefault;
-				"INFOPLIST_KEY_UIStatusBarStyle[sdk=iphonesimulator*]" = UIStatusBarStyleDefault;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "se-masked-quiz/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";

--- a/ios/se-masked-quiz/Info.plist
+++ b/ios/se-masked-quiz/Info.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>semaskedquiz</string>
+			</array>
+		</dict>
+	</array>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.entertainment</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UIStatusBarStyle</key>
+	<string>UIStatusBarStyleDefault</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -86,7 +86,7 @@ struct ProposalListScreen: View {
     Task { await loadQuizProgresses() }
   }
 
-  /// 通知タップ/DeepLinkで保留中のチャレンジが自分のtrackと一致すれば取得して遷移する
+  /// SE/STタブが同一のDeepLinkRouterインスタンスを共有するため、track不一致の通知/DeepLinkは無視して誤消費を防ぐ
   private func handlePendingChallenge(_ pending: DeepLinkRouter.PendingChallenge?) {
     guard let pending, pending.track == track else { return }
     Task {
@@ -194,7 +194,11 @@ struct ProposalListScreen: View {
             NavigationLink(value: daily) {
               DailyChallengeCard(proposal: daily)
             }
-            NavigationLink(value: StreakStatsRoute()) {
+            // List内でNavigationLinkを2つ並べると開示矢印(chevron)が重複し、
+            // 行の幅計算が崩れてDailyChallengeCard側が圧縮されてしまうためButtonで代替する
+            Button {
+              navigationPath.append(StreakStatsRoute())
+            } label: {
               Image(systemName: "chart.bar.xaxis")
                 .font(.title3)
                 .foregroundStyle(.secondary)

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -13,6 +13,7 @@ struct ProposalListScreen: View {
   @Environment(\.testingQuizRepository) var testingQuizRepository
   @Environment(\.streakRepository) var streakRepository
   @Environment(\.analytics) var analytics
+  @Environment(DeepLinkRouter.self) private var router
   @State private var proposals: AsyncProposals = .idle
   @State private var dailyProposal: SwiftEvolution?
   @State private var modalWebUrl: URL?
@@ -70,6 +71,11 @@ struct ProposalListScreen: View {
       .sheet(item: $modalWebUrl) { url in
         webPreviewSheet(url: url, proxy: proxy)
       }
+      // initial: true でコールドスタート時（Viewが表示される前に通知/DeepLinkが処理済みの場合）も
+      // 既存の pendingChallenge を取りこぼさないようにする
+      .onChange(of: router.pendingChallenge, initial: true) { _, newValue in
+        handlePendingChallenge(newValue)
+      }
     }
   }
 
@@ -78,6 +84,19 @@ struct ProposalListScreen: View {
   private func handleNavigationPathChange(oldCount: Int, newCount: Int) {
     guard newCount < oldCount else { return }
     Task { await loadQuizProgresses() }
+  }
+
+  /// 通知タップ/DeepLinkで保留中のチャレンジが自分のtrackと一致すれば取得して遷移する
+  private func handlePendingChallenge(_ pending: DeepLinkRouter.PendingChallenge?) {
+    guard let pending, pending.track == track else { return }
+    Task {
+      guard
+        let proposal = try? await repository.fetchProposal(
+          byProposalId: pending.proposalId, track: track)
+      else { return }
+      navigationPath.append(proposal)
+      router.pendingChallenge = nil
+    }
   }
 
   private func debounceSearchText() async {
@@ -171,8 +190,16 @@ struct ProposalListScreen: View {
     List {
       if let daily = dailyProposal {
         Section {
-          NavigationLink(value: daily) {
-            DailyChallengeCard(proposal: daily)
+          HStack {
+            NavigationLink(value: daily) {
+              DailyChallengeCard(proposal: daily)
+            }
+            NavigationLink(value: StreakStatsRoute()) {
+              Image(systemName: "chart.bar.xaxis")
+                .font(.title3)
+                .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.borderless)
           }
         }
       }
@@ -229,6 +256,9 @@ struct ProposalListScreen: View {
         rootProposalId: route.rootProposalId,
         rootTitle: route.rootTitle
       )
+    }
+    .navigationDestination(for: StreakStatsRoute.self) { _ in
+      StreakStatsScreen()
     }
     .toolbar {
       #if os(iOS)

--- a/ios/se-masked-quiz/ProposalFeature/StreakStatsScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/StreakStatsScreen.swift
@@ -1,0 +1,166 @@
+//
+//  StreakStatsScreen.swift
+//  se-masked-quiz
+//
+//  デイリーチャレンジの達成状況を俯瞰する統計画面。
+//  現在/最長ストリーク・総学習日数・正答率のサマリと、直近7日/180日の学習履歴を可視化する。
+//
+
+import SwiftUI
+
+/// ストリーク統計画面への遷移値。NavigationStack の value-based 遷移で使う。
+struct StreakStatsRoute: Hashable {}
+
+struct StreakStatsScreen: View {
+  @Environment(\.streakRepository) private var streakRepository
+  @Environment(\.quizRepository) private var quizRepository
+  @Environment(\.testingQuizRepository) private var testingQuizRepository
+
+  @State private var streak: StreakRecord = .empty
+  @State private var accuracy: QuizAccuracyAggregator.Result?
+
+  private let calendar = Calendar.current
+
+  var body: some View {
+    List {
+      Section {
+        statsGrid
+      }
+      Section("直近7日") {
+        weekDots
+          .padding(.vertical, 4)
+      }
+      Section("学習の記録（直近180日）") {
+        activityGrid
+          .padding(.vertical, 4)
+      }
+    }
+    .navigationTitle("ストリーク統計")
+    .task {
+      await loadData()
+    }
+  }
+
+  // MARK: - Stats Grid
+
+  private var statsGrid: some View {
+    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+      statTile(
+        title: "現在のストリーク", value: "\(streak.currentStreak)日", icon: "flame.fill", color: .orange)
+      statTile(
+        title: "最長ストリーク", value: "\(streak.longestStreak)日", icon: "trophy.fill", color: .yellow)
+      statTile(
+        title: "総学習日数", value: "\(streak.totalActiveDays)日", icon: "calendar", color: .blue)
+      statTile(
+        title: "正答率", value: accuracyText, icon: "checkmark.seal.fill", color: .green)
+    }
+    .listRowInsets(EdgeInsets())
+    .listRowBackground(Color.clear)
+  }
+
+  private var accuracyText: String {
+    guard let percentage = accuracy?.accuracyPercentage else { return "―" }
+    return "\(Int(percentage))%"
+  }
+
+  private func statTile(title: String, value: String, icon: String, color: Color) -> some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Label(title, systemImage: icon)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      Text(value)
+        .font(.title2.weight(.bold))
+        .monospacedDigit()
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding()
+    .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 12))
+  }
+
+  // MARK: - Week Dots
+
+  private var last7Days: [Date] {
+    recentDays(count: 7)
+  }
+
+  private var weekDots: some View {
+    HStack(spacing: 12) {
+      ForEach(last7Days, id: \.self) { day in
+        VStack(spacing: 4) {
+          Circle()
+            .fill(isActive(on: day) ? Color.green : Color.gray.opacity(0.2))
+            .frame(width: 28, height: 28)
+            .overlay {
+              if calendar.isDateInToday(day) {
+                Circle().strokeBorder(Color.orange, lineWidth: 2)
+              }
+            }
+          Text(weekdaySymbol(for: day))
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+          "\(weekdaySymbol(for: day))曜日 \(isActive(on: day) ? "達成" : "未達成")")
+      }
+    }
+    .frame(maxWidth: .infinity)
+  }
+
+  // MARK: - Activity Grid
+
+  private var last180Days: [Date] {
+    recentDays(count: StreakRecord.activeDaysRetentionDays)
+  }
+
+  private var activityGrid: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      LazyHGrid(
+        rows: Array(repeating: GridItem(.fixed(12), spacing: 3), count: 7),
+        spacing: 3
+      ) {
+        ForEach(last180Days, id: \.self) { day in
+          RoundedRectangle(cornerRadius: 2)
+            .fill(isActive(on: day) ? Color.green : Color.gray.opacity(0.15))
+            .frame(width: 12, height: 12)
+        }
+      }
+      .padding(.vertical, 2)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private var activeDaySet: Set<Date> {
+    Set(streak.activeDays.map { calendar.startOfDay(for: $0) })
+  }
+
+  private func isActive(on day: Date) -> Bool {
+    activeDaySet.contains(calendar.startOfDay(for: day))
+  }
+
+  private func recentDays(count: Int) -> [Date] {
+    let today = calendar.startOfDay(for: Date())
+    return (0..<count).reversed().compactMap { offset in
+      calendar.date(byAdding: .day, value: -offset, to: today)
+    }
+  }
+
+  private func weekdaySymbol(for date: Date) -> String {
+    let weekdayIndex = calendar.component(.weekday, from: date) - 1
+    return calendar.veryShortWeekdaySymbols[weekdayIndex]
+  }
+
+  private func loadData() async {
+    streak = await streakRepository.getStreak()
+    let seScores = await quizRepository.getAllScores()
+    let stScores = await testingQuizRepository.getAllScores()
+    accuracy = QuizAccuracyAggregator().aggregate(scoresByTrack: [seScores, stScores])
+  }
+}
+
+#Preview {
+  NavigationStack {
+    StreakStatsScreen()
+  }
+}

--- a/ios/se-masked-quiz/Repositories/StreakRepository.swift
+++ b/ios/se-masked-quiz/Repositories/StreakRepository.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 /// 連続学習日数（ストリーク）の状態
 struct StreakRecord: Codable, Equatable, Sendable {
-  /// 達成状況を俯瞰表示するために保持する、直近の学習日履歴（180日ローリング）
+  /// 達成状況を俯瞰表示するために、直近の学習日履歴（180日ローリング）を保持する
   static let activeDaysRetentionDays = 180
 
   var currentStreak: Int

--- a/ios/se-masked-quiz/Repositories/StreakRepository.swift
+++ b/ios/se-masked-quiz/Repositories/StreakRepository.swift
@@ -13,14 +13,41 @@ import SwiftUI
 
 /// 連続学習日数（ストリーク）の状態
 struct StreakRecord: Codable, Equatable, Sendable {
+  /// 達成状況を俯瞰表示するために保持する、直近の学習日履歴（180日ローリング）
+  static let activeDaysRetentionDays = 180
+
   var currentStreak: Int
   var longestStreak: Int
   /// 最後に学習した日（その日の startOfDay）
   var lastActiveDay: Date?
   var totalActiveDays: Int
+  /// 直近 `activeDaysRetentionDays` 日分の学習日（startOfDay）。古いものから随時トリムされる。
+  var activeDays: [Date]
 
   static let empty = StreakRecord(
-    currentStreak: 0, longestStreak: 0, lastActiveDay: nil, totalActiveDays: 0)
+    currentStreak: 0, longestStreak: 0, lastActiveDay: nil, totalActiveDays: 0, activeDays: [])
+
+  init(
+    currentStreak: Int, longestStreak: Int, lastActiveDay: Date?, totalActiveDays: Int,
+    activeDays: [Date] = []
+  ) {
+    self.currentStreak = currentStreak
+    self.longestStreak = longestStreak
+    self.lastActiveDay = lastActiveDay
+    self.totalActiveDays = totalActiveDays
+    self.activeDays = activeDays
+  }
+
+  // 旧バージョンで保存された `activeDays` キーを持たない JSON を安全にデコードするため、
+  // 自動合成の Decodable ではなく明示的にキー欠落を許容する。
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    currentStreak = try container.decode(Int.self, forKey: .currentStreak)
+    longestStreak = try container.decode(Int.self, forKey: .longestStreak)
+    lastActiveDay = try container.decodeIfPresent(Date.self, forKey: .lastActiveDay)
+    totalActiveDays = try container.decode(Int.self, forKey: .totalActiveDays)
+    activeDays = try container.decodeIfPresent([Date].self, forKey: .activeDays) ?? []
+  }
 
   /// 指定日に学習済みか
   func isActive(on date: Date, calendar: Calendar = .current) -> Bool {
@@ -100,6 +127,12 @@ actor StreakRepositoryImpl: StreakRepository {
     record.lastActiveDay = today
     record.totalActiveDays += 1
     record.longestStreak = max(record.longestStreak, record.currentStreak)
+    record.activeDays.append(today)
+    if let cutoff = calendar.date(
+      byAdding: .day, value: -StreakRecord.activeDaysRetentionDays, to: today)
+    {
+      record.activeDays.removeAll { $0 < cutoff }
+    }
     saveRecord(record)
 
     return StreakUpdateResult(record: record, didIncrement: didIncrement, isFirstActivityToday: true)

--- a/ios/se-masked-quiz/Services/AppNotificationDelegate.swift
+++ b/ios/se-masked-quiz/Services/AppNotificationDelegate.swift
@@ -1,0 +1,40 @@
+//
+//  AppNotificationDelegate.swift
+//  se-masked-quiz
+//
+//  通知タップを DeepLinkRouter に橋渡しする UNUserNotificationCenterDelegate 実装。
+//  フォアグラウンド中も通知バナーを表示し、タップ時のみ遷移処理を行う。
+//
+
+import Foundation
+import UserNotifications
+
+final class AppNotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
+  private let router: DeepLinkRouter
+  private let analytics: any AnalyticsService
+
+  init(router: DeepLinkRouter, analytics: any AnalyticsService) {
+    self.router = router
+    self.analytics = analytics
+  }
+
+  /// フォアグラウンド中に通知が届いた場合も、バックグラウンド同様にバナー・サウンドを表示する
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    willPresent notification: UNNotification
+  ) async -> UNNotificationPresentationOptions {
+    [.banner, .sound, .badge]
+  }
+
+  /// 通知タップ時に呼ばれる。userInfo を DeepLinkRouter に渡し、開封を計測する。
+  func userNotificationCenter(
+    _ center: UNUserNotificationCenter,
+    didReceive response: UNNotificationResponse
+  ) async {
+    let userInfo = response.notification.request.content.userInfo
+    await MainActor.run {
+      router.handle(userInfo: userInfo)
+      analytics.track(.notificationOpened)
+    }
+  }
+}

--- a/ios/se-masked-quiz/Services/AppNotificationDelegate.swift
+++ b/ios/se-masked-quiz/Services/AppNotificationDelegate.swift
@@ -18,7 +18,7 @@ final class AppNotificationDelegate: NSObject, UNUserNotificationCenterDelegate 
     self.analytics = analytics
   }
 
-  /// フォアグラウンド中に通知が届いた場合も、バックグラウンド同様にバナー・サウンドを表示する
+  /// 表示中の通知もタップして直接チャレンジを開けるよう、フォアグラウンド中もバナー表示させる
   func userNotificationCenter(
     _ center: UNUserNotificationCenter,
     willPresent notification: UNNotification

--- a/ios/se-masked-quiz/Services/DeepLinkRouter.swift
+++ b/ios/se-masked-quiz/Services/DeepLinkRouter.swift
@@ -1,0 +1,67 @@
+//
+//  DeepLinkRouter.swift
+//  se-masked-quiz
+//
+//  Custom URL Scheme（semaskedquiz://challenge?...）と通知タップの userInfo、
+//  両方の入口を共通ロジックで捌き、該当タブ選択とチャレンジ画面への遷移を仲介する。
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class DeepLinkRouter {
+  /// `UNMutableNotificationContent.userInfo` に載せるキー。
+  /// NotificationService（送信側）と本クラス（受信側）の双方から参照される。
+  enum UserInfoKey {
+    static let track = "track"
+    static let proposalId = "proposalId"
+  }
+
+  struct PendingChallenge: Equatable {
+    let track: ProposalTrack
+    let proposalId: String
+  }
+
+  /// DeepLink/通知に応じて切り替えるタブ
+  var selectedTrack: ProposalTrack = .swiftEvolution
+  /// 各 `ProposalListScreen` が自分の track と一致した時に消費する保留中のチャレンジ
+  var pendingChallenge: PendingChallenge?
+
+  /// `semaskedquiz://challenge?track=swiftEvolution&proposalId=SE-0401` 形式のURLを処理する
+  func handle(url: URL) {
+    guard url.scheme == "semaskedquiz", url.host == "challenge",
+      let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems,
+      let trackRaw = items.first(where: { $0.name == "track" })?.value,
+      let track = ProposalTrack(rawValue: trackRaw),
+      let rawId = items.first(where: { $0.name == "proposalId" })?.value
+    else { return }
+    applyChallenge(track: track, proposalId: rawId)
+  }
+
+  /// 通知タップ時の `UNNotificationResponse.notification.request.content.userInfo` を処理する
+  func handle(userInfo: [AnyHashable: Any]) {
+    guard let trackRaw = userInfo[UserInfoKey.track] as? String,
+      let track = ProposalTrack(rawValue: trackRaw),
+      let rawId = userInfo[UserInfoKey.proposalId] as? String
+    else { return }
+    applyChallenge(track: track, proposalId: rawId)
+  }
+
+  private func applyChallenge(track: ProposalTrack, proposalId: String) {
+    selectedTrack = track
+    pendingChallenge = PendingChallenge(track: track, proposalId: Self.normalize(proposalId))
+  }
+
+  /// "SE-0401" / "ST-0012" のような表示用接頭辞を除去し、bare形式のproposalIdに正規化する
+  static func normalize(_ rawId: String) -> String {
+    for track in ProposalTrack.allCases {
+      let prefix = "\(track.displayPrefix)-"
+      if rawId.hasPrefix(prefix) {
+        return String(rawId.dropFirst(prefix.count))
+      }
+    }
+    return rawId
+  }
+}

--- a/ios/se-masked-quiz/Services/NotificationService.swift
+++ b/ios/se-masked-quiz/Services/NotificationService.swift
@@ -57,7 +57,15 @@ struct NotificationService: Sendable {
 
   /// 毎日指定時刻のリマインダーを登録（既存があれば置き換え）。
   /// 本文には現在のストリーク日数を埋め込み、継続意欲（loss aversion）を刺激する。
-  func scheduleDailyReminder(hour: Int, minute: Int, currentStreak: Int) async {
+  /// `track`/`proposalId` を渡すと、通知タップで該当のデイリーチャレンジへ直接遷移できる
+  /// DeepLink情報を `userInfo` に埋め込む（取得できなければ従来どおり付与しない）。
+  func scheduleDailyReminder(
+    hour: Int,
+    minute: Int,
+    currentStreak: Int,
+    track: ProposalTrack? = nil,
+    proposalId: String? = nil
+  ) async {
     let center = UNUserNotificationCenter.current()
     center.removePendingNotificationRequests(withIdentifiers: [Self.dailyReminderIdentifier])
 
@@ -69,6 +77,12 @@ struct NotificationService: Sendable {
       content.body = "1日1問でも続ければ力になります。今日のチャレンジを始めましょう。"
     }
     content.sound = .default
+    if let track, let proposalId {
+      content.userInfo = [
+        DeepLinkRouter.UserInfoKey.track: track.rawValue,
+        DeepLinkRouter.UserInfoKey.proposalId: proposalId,
+      ]
+    }
 
     var components = DateComponents()
     components.hour = hour

--- a/ios/se-masked-quiz/Services/QuizAccuracyAggregator.swift
+++ b/ios/se-masked-quiz/Services/QuizAccuracyAggregator.swift
@@ -1,0 +1,35 @@
+//
+//  QuizAccuracyAggregator.swift
+//  se-masked-quiz
+//
+//  SE/ST 両トラックのスコアを横断して正答率を集計する純粋ロジック。
+//  サーバ不要・オフライン可・テスト容易（DailyChallengeService と同じ設計思想）。
+//
+
+import Foundation
+
+struct QuizAccuracyAggregator: Sendable {
+  struct Result: Sendable, Equatable {
+    let totalAnswered: Int
+    let totalCorrect: Int
+
+    /// 未回答なら nil、それ以外は 0〜100 の正答率
+    var accuracyPercentage: Double? {
+      guard totalAnswered > 0 else { return nil }
+      return Double(totalCorrect) / Double(totalAnswered) * 100
+    }
+  }
+
+  /// 複数トラックの `getAllScores()` 結果を横断集計する
+  func aggregate(scoresByTrack: [[String: ProposalScore]]) -> Result {
+    var totalAnswered = 0
+    var totalCorrect = 0
+    for scores in scoresByTrack {
+      for score in scores.values {
+        totalAnswered += score.totalCount
+        totalCorrect += score.correctCount
+      }
+    }
+    return Result(totalAnswered: totalAnswered, totalCorrect: totalCorrect)
+  }
+}

--- a/ios/se-masked-quiz/se_masked_quizApp.swift
+++ b/ios/se-masked-quiz/se_masked_quizApp.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UserNotifications
 
 @main
 struct se_masked_quizApp: App {
@@ -13,22 +14,38 @@ struct se_masked_quizApp: App {
 
   private let analytics: any AnalyticsService = ConsoleAnalyticsService()
   private let streakRepository: any StreakRepository = StreakRepositoryImpl()
+  private let quizRepository: any QuizRepository = QuizRepositoryImpl()
   private let notificationService = NotificationService()
+  private let router: DeepLinkRouter
+  private let notificationDelegate: AppNotificationDelegate
+
+  init() {
+    let router = DeepLinkRouter()
+    self.router = router
+    self.notificationDelegate = AppNotificationDelegate(router: router, analytics: analytics)
+    UNUserNotificationCenter.current().delegate = notificationDelegate
+  }
 
   var body: some Scene {
     WindowGroup {
-      TabView {
+      TabView(selection: Bindable(router).selectedTrack) {
         ProposalListScreen(track: .swiftEvolution)
           .tabItem {
             Label("Swift Evolution", systemImage: "swift")
           }
+          .tag(ProposalTrack.swiftEvolution)
         ProposalListScreen(track: .swiftTesting)
           .tabItem {
             Label("Swift Testing", systemImage: "checkmark.seal")
           }
+          .tag(ProposalTrack.swiftTesting)
       }
       .environment(\.analytics, analytics)
       .environment(\.streakRepository, streakRepository)
+      .environment(router)
+      .onOpenURL { url in
+        router.handle(url: url)
+      }
     }
     .onChange(of: scenePhase) { _, newPhase in
       guard newPhase == .active else { return }
@@ -36,18 +53,28 @@ struct se_masked_quizApp: App {
     }
   }
 
-  /// 起動・前面復帰時：起動計測と、リマインダー本文の最新ストリークへの更新
+  /// 起動・前面復帰時：起動計測と、リマインダー本文の最新ストリーク・DeepLink情報への更新
   private func handleBecameActive() {
     analytics.track(.appOpen)
 
     guard ReminderPreferences.isEnabled else { return }
     Task {
       let streak = await streakRepository.getStreak()
+      let proposalId = await todaysSEProposalId()
       await notificationService.scheduleDailyReminder(
         hour: ReminderPreferences.hour,
         minute: ReminderPreferences.minute,
-        currentStreak: streak.currentStreak
+        currentStreak: streak.currentStreak,
+        track: proposalId != nil ? .swiftEvolution : nil,
+        proposalId: proposalId
       )
     }
+  }
+
+  /// 通知タップで直接デイリーチャレンジへ遷移できるよう、今日のSE提案IDを算出する。
+  /// 取得できない場合はnilを返し、呼び出し元でDeepLink情報なしのフォールバック予約にする。
+  private func todaysSEProposalId() async -> String? {
+    guard let counts = try? await quizRepository.getAllQuizCounts() else { return nil }
+    return DailyChallengeService().todaysProposalId(from: Array(counts.keys), date: Date())
   }
 }

--- a/ios/se-masked-quizTests/DeepLinkRouterTests.swift
+++ b/ios/se-masked-quizTests/DeepLinkRouterTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("DeepLinkRouter Tests")
+@MainActor
+struct DeepLinkRouterTests {
+
+  // MARK: - handle(url:)
+
+  @Test("正常なURLでtrackとproposalIdが設定される（SE接頭辞は除去される）")
+  func handleURLWithSEPrefix() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://challenge?track=swiftEvolution&proposalId=SE-0401")!
+    sut.handle(url: url)
+    #expect(sut.selectedTrack == .swiftEvolution)
+    #expect(
+      sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
+        track: .swiftEvolution, proposalId: "0401"))
+  }
+
+  @Test("ST接頭辞も除去される")
+  func handleURLWithSTPrefix() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://challenge?track=swiftTesting&proposalId=ST-0012")!
+    sut.handle(url: url)
+    #expect(sut.selectedTrack == .swiftTesting)
+    #expect(
+      sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
+        track: .swiftTesting, proposalId: "0012"))
+  }
+
+  @Test("接頭辞の無いbare proposalIdはそのまま使われる")
+  func handleURLWithoutPrefix() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://challenge?track=swiftEvolution&proposalId=0401")!
+    sut.handle(url: url)
+    #expect(sut.pendingChallenge?.proposalId == "0401")
+  }
+
+  @Test("不正なtrackはpendingChallengeを更新しない")
+  func handleURLWithInvalidTrack() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://challenge?track=unknown&proposalId=0401")!
+    sut.handle(url: url)
+    #expect(sut.pendingChallenge == nil)
+  }
+
+  @Test("proposalIdパラメータの欠落はpendingChallengeを更新しない")
+  func handleURLWithoutProposalId() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://challenge?track=swiftEvolution")!
+    sut.handle(url: url)
+    #expect(sut.pendingChallenge == nil)
+  }
+
+  @Test("不正なホストは無視される")
+  func handleURLWithWrongHost() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "semaskedquiz://other?track=swiftEvolution&proposalId=0401")!
+    sut.handle(url: url)
+    #expect(sut.pendingChallenge == nil)
+  }
+
+  @Test("不正なスキームは無視される")
+  func handleURLWithWrongScheme() {
+    let sut = DeepLinkRouter()
+    let url = URL(string: "https://challenge?track=swiftEvolution&proposalId=0401")!
+    sut.handle(url: url)
+    #expect(sut.pendingChallenge == nil)
+  }
+
+  // MARK: - handle(userInfo:)
+
+  @Test("正常なuserInfoでtrackとproposalIdが設定される")
+  func handleUserInfoValid() {
+    let sut = DeepLinkRouter()
+    sut.handle(userInfo: [
+      DeepLinkRouter.UserInfoKey.track: "swiftEvolution",
+      DeepLinkRouter.UserInfoKey.proposalId: "SE-0401",
+    ])
+    #expect(sut.selectedTrack == .swiftEvolution)
+    #expect(
+      sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
+        track: .swiftEvolution, proposalId: "0401"))
+  }
+
+  @Test("不正なtrackのuserInfoはpendingChallengeを更新しない")
+  func handleUserInfoInvalidTrack() {
+    let sut = DeepLinkRouter()
+    sut.handle(userInfo: [
+      DeepLinkRouter.UserInfoKey.track: "unknown",
+      DeepLinkRouter.UserInfoKey.proposalId: "0401",
+    ])
+    #expect(sut.pendingChallenge == nil)
+  }
+
+  @Test("proposalId欠落のuserInfoはpendingChallengeを更新しない")
+  func handleUserInfoMissingProposalId() {
+    let sut = DeepLinkRouter()
+    sut.handle(userInfo: [
+      DeepLinkRouter.UserInfoKey.track: "swiftEvolution"
+    ])
+    #expect(sut.pendingChallenge == nil)
+  }
+}

--- a/ios/se-masked-quizTests/QuizAccuracyAggregatorTests.swift
+++ b/ios/se-masked-quizTests/QuizAccuracyAggregatorTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("QuizAccuracyAggregator Tests")
+struct QuizAccuracyAggregatorTests {
+
+  private func score(proposalId: String, correct: Int, incorrect: Int) -> ProposalScore {
+    let correctResults = (0..<correct).map {
+      QuestionResult(index: $0, isCorrect: true, answer: "a", userAnswer: "a")
+    }
+    let incorrectResults = (0..<incorrect).map {
+      QuestionResult(index: correct + $0, isCorrect: false, answer: "a", userAnswer: "b")
+    }
+    return ProposalScore(proposalId: proposalId, questionResults: correctResults + incorrectResults)
+  }
+
+  @Test("未回答なら正答率はnil")
+  func emptyReturnsNil() {
+    let sut = QuizAccuracyAggregator()
+    let result = sut.aggregate(scoresByTrack: [[:], [:]])
+    #expect(result.totalAnswered == 0)
+    #expect(result.totalCorrect == 0)
+    #expect(result.accuracyPercentage == nil)
+  }
+
+  @Test("単一トラックの正答率を計算する")
+  func singleTrack() {
+    let sut = QuizAccuracyAggregator()
+    let scores = ["SE-0001": score(proposalId: "SE-0001", correct: 3, incorrect: 1)]
+    let result = sut.aggregate(scoresByTrack: [scores])
+    #expect(result.totalAnswered == 4)
+    #expect(result.totalCorrect == 3)
+    #expect(result.accuracyPercentage == 75.0)
+  }
+
+  @Test("SE/ST両トラックを横断して集計する")
+  func mixedTracks() {
+    let sut = QuizAccuracyAggregator()
+    let seScores = ["0001": score(proposalId: "0001", correct: 2, incorrect: 2)]
+    let stScores = ["0001": score(proposalId: "0001", correct: 4, incorrect: 0)]
+    let result = sut.aggregate(scoresByTrack: [seScores, stScores])
+    #expect(result.totalAnswered == 8)
+    #expect(result.totalCorrect == 6)
+    #expect(result.accuracyPercentage == 75.0)
+  }
+}

--- a/ios/se-masked-quizTests/StreakRepositoryTests.swift
+++ b/ios/se-masked-quizTests/StreakRepositoryTests.swift
@@ -97,4 +97,67 @@ struct StreakRepositoryTests {
     let record = await sut.getStreak()
     #expect(record == .empty)
   }
+
+  // MARK: - activeDays
+
+  @Test("学習するとactiveDaysに日付が追加される")
+  func activeDaysAppended() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    let result = await sut.recordActivity(on: day(2026, 1, 2))
+    #expect(result.record.activeDays.count == 2)
+    #expect(
+      result.record.activeDays.contains { utcCalendar.isDate($0, inSameDayAs: day(2026, 1, 1)) })
+    #expect(
+      result.record.activeDays.contains { utcCalendar.isDate($0, inSameDayAs: day(2026, 1, 2)) })
+  }
+
+  @Test("同日に複数回記録してもactiveDaysに重複しない")
+  func noDuplicateActiveDaysForSameDay() async {
+    let sut = makeSUT()
+    _ = await sut.recordActivity(on: day(2026, 1, 1))
+    let second = await sut.recordActivity(on: day(2026, 1, 1))
+    #expect(second.record.activeDays.count == 1)
+  }
+
+  @Test("180日を超える古い活動日はトリムされる")
+  func trimsOldActiveDays() async {
+    let suiteName = "streak-test-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+
+    let oldDay = day(2025, 1, 1)
+    let seedRecord = StreakRecord(
+      currentStreak: 1, longestStreak: 1, lastActiveDay: oldDay, totalActiveDays: 1,
+      activeDays: [oldDay])
+    let encoded = try! JSONEncoder().encode(seedRecord)
+    defaults.set(encoded, forKey: "streak_record")
+
+    let sut = StreakRepositoryImpl(userDefaults: defaults, calendar: utcCalendar)
+    let today = day(2026, 7, 25)
+    let result = await sut.recordActivity(on: today)
+
+    #expect(
+      !result.record.activeDays.contains { utcCalendar.isDate($0, inSameDayAs: oldDay) })
+    #expect(
+      result.record.activeDays.contains { utcCalendar.isDate($0, inSameDayAs: today) })
+  }
+
+  @Test("activeDaysキーの無い旧データも安全にデコードできる")
+  func decodesLegacyDataWithoutActiveDays() throws {
+    struct LegacyStreakRecord: Codable {
+      var currentStreak: Int
+      var longestStreak: Int
+      var lastActiveDay: Date?
+      var totalActiveDays: Int
+    }
+    let legacy = LegacyStreakRecord(
+      currentStreak: 3, longestStreak: 5, lastActiveDay: day(2026, 1, 1), totalActiveDays: 10)
+    let data = try JSONEncoder().encode(legacy)
+    let record = try JSONDecoder().decode(StreakRecord.self, from: data)
+    #expect(record.currentStreak == 3)
+    #expect(record.longestStreak == 5)
+    #expect(record.totalActiveDays == 10)
+    #expect(record.activeDays == [])
+  }
 }


### PR DESCRIPTION
## 概要

- デイリーチャレンジ通知をタップした際に、該当するチャレンジ画面へ直接遷移できるDeepLink連携を追加
- ストリーク達成状況を俯瞰できる専用統計画面を新設

## 背景・目的

- 通知をタップしても即座にチャレンジを開始できず、アプリ内で該当提案を探す必要があった
- デイリーチャレンジの達成状況が炎バッジの数値のみで、履歴や週次/月次の傾向を俯瞰できなかった

## 主要な変更点

### 通知DeepLink連携
- Custom URL Scheme (`semaskedquiz://challenge?track=...&proposalId=...`) を追加
- `NotificationService`: 通知の`userInfo`に当日のtrack/proposalIdを付与
- `DeepLinkRouter`: URL/通知タップ共通のハンドリングと`SE-`/`ST-`接頭辞正規化を新設
- `AppNotificationDelegate`: 通知タップ捕捉とフォアグラウンドバナー表示を新設
- `se_masked_quizApp`: `TabView`をtrack選択可能にし、ルーターを配線
- `ProposalListScreen`: 保留中チャレンジを消費して画面遷移（コールドスタート起動時も取りこぼさないよう対応）

### ストリーク統計画面
- `StreakRecord`に直近180日の学習日履歴(`activeDays`)を追加（旧データも安全にデコード可能）
- `QuizAccuracyAggregator`: SE/ST横断の正答率集計ロジックを新設
- `StreakStatsScreen`: 現在/最長ストリーク・総学習日数・正答率・週間ドット・180日ヒートマップで達成状況を俯瞰できる画面を新設
- `DailyChallengeCard`の隣に統計画面への導線を追加

### その他
- `GENERATE_INFOPLIST_FILE=YES`では配列型キー(`CFBundleURLTypes`)を追加できないことが実装中に判明したため、明示的な`Info.plist`に切り替え。Xcode 16のSynchronized Groups機能によるビルドリソース重複はexception設定で回避
- **レイアウト崩れ修正**: デイリーチャレンジ行で`HStack`内に`NavigationLink`を2つ並べていたことで、List行の開示矢印(chevron)が重複し`DailyChallengeCard`のテキストが縦に圧縮される不具合を実機確認で発見。統計画面への遷移リンクを`NavigationLink`から`Button`(`navigationPath.append(StreakStatsRoute())`による手動遷移)に変更して解消。あわせて、動作の説明に留まっていたコメントを3箇所、WHYが伝わる文面に整理

## テスト

- [x] `StreakRepositoryTests` / `QuizAccuracyAggregatorTests` / `DeepLinkRouterTests` を追加、全ユニットテスト成功
- [x] 実機ビルド成功（`xcodebuild build`）
- [x] `swift-complexity --threshold 10` チェック成功（閾値超過なし）
- [x] シミュレータでデイリーチャレンジ行のレイアウトを目視確認（修正前後のスクリーンショット比較済み）
- [ ] シミュレータ/実機でのSafari経由URLタップ、通知タップ（フォアグラウンド/バックグラウンド/コールドスタート）の実機インタラクション確認は未実施

## レビューポイント

- `DeepLinkRouter`を`@Observable`で新設し、既存の`EnvironmentKey`ベースDIパターンと並行導入している点（TabViewの`selection`バインディングに`@Observable`+`.environment(_:)`が必要だったため）
- `Info.plist`を明示ファイル化した点（Xcode GUI操作の代替として`project.pbxproj`を直接編集）

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->
