### PR TITLE
お気に入り機能を追加

### DIFF
--- a/ios/se-masked-quiz/DesignSystem/Components/FavoriteButton.swift
+++ b/ios/se-masked-quiz/DesignSystem/Components/FavoriteButton.swift
@@ -1,0 +1,32 @@
+//
+//  FavoriteButton.swift
+//  se-masked-quiz
+//
+//  提案一覧の各行でお気に入り状態をトグルするボタン。
+//  List内でNavigationLinkと並べても開示矢印が重複しないよう、Buttonベースで実装する。
+//
+
+import SwiftUI
+
+struct FavoriteButton: View {
+  let isFavorite: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Image(systemName: isFavorite ? "bookmark.fill" : "bookmark")
+        .foregroundStyle(isFavorite ? AnyShapeStyle(SemanticColor.accent) : AnyShapeStyle(Color.secondary))
+        .frame(minWidth: 44, minHeight: 44)
+    }
+    .buttonStyle(.borderless)
+    .accessibilityLabel(isFavorite ? "お気に入り解除" : "お気に入りに追加")
+  }
+}
+
+#Preview("未登録") {
+  FavoriteButton(isFavorite: false, action: {})
+}
+
+#Preview("登録済み") {
+  FavoriteButton(isFavorite: true, action: {})
+}

--- a/ios/se-masked-quiz/Models/FavoriteEntry.swift
+++ b/ios/se-masked-quiz/Models/FavoriteEntry.swift
@@ -1,0 +1,17 @@
+//
+//  FavoriteEntry.swift
+//  se-masked-quiz
+//
+//  お気に入り登録された提案を表す。proposalId は SE/ST 間で衝突しうる
+//  bare 4桁のため、track を保持して個別に区別する。
+//
+
+import Foundation
+
+struct FavoriteEntry: Codable, Equatable, Sendable, Identifiable {
+  var id: String { "\(track.rawValue)_\(proposalId)" }
+
+  let proposalId: String
+  let track: ProposalTrack
+  let addedAt: Date
+}

--- a/ios/se-masked-quiz/ProposalFeature/FavoritesScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/FavoritesScreen.swift
@@ -1,0 +1,95 @@
+//
+//  FavoritesScreen.swift
+//  se-masked-quiz
+//
+//  お気に入り登録された提案をSE/ST横断で一覧表示する画面。
+//
+
+import SwiftUI
+
+/// お気に入り画面への遷移値。NavigationStack の value-based 遷移で使う。
+struct FavoritesRoute: Hashable {}
+
+struct FavoritesScreen: View {
+  @Environment(\.seRepository) private var repository
+  @Environment(\.favoriteRepository) private var favoriteRepository
+
+  @State private var resolvedFavorites: [ResolvedFavorite] = []
+  @State private var isLoading = true
+
+  var body: some View {
+    List {
+      ForEach(resolvedFavorites) { resolved in
+        NavigationLink(value: resolved.proposal) {
+          VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            HStack {
+              MarkdownText(resolved.proposal.title)
+                .font(AppFont.headline)
+              Text(resolved.proposal.displayId)
+                .font(AppFont.caption)
+            }
+            MarkdownText(resolved.proposal.authors)
+              .font(AppFont.subheadline)
+          }
+        }
+      }
+    }
+    .overlay {
+      if !isLoading && resolvedFavorites.isEmpty {
+        ContentUnavailableView(
+          "お気に入りはまだありません",
+          systemImage: "bookmark",
+          description: Text("提案一覧のブックマークアイコンをタップすると、ここに追加されます。")
+        )
+      }
+    }
+    .navigationTitle("お気に入り")
+    .task {
+      await loadFavoriteProposals()
+    }
+  }
+
+  private func loadFavoriteProposals() async {
+    isLoading = true
+    defer { isLoading = false }
+
+    let entries = await favoriteRepository.getAllFavorites()
+    let resolved = await withTaskGroup(of: ResolvedFavorite?.self) { group in
+      for entry in entries {
+        group.addTask {
+          do {
+            guard
+              let proposal = try await repository.fetchProposal(
+                byProposalId: entry.proposalId, track: entry.track)
+            else { return nil }
+            return ResolvedFavorite(entry: entry, proposal: proposal)
+          } catch {
+            // 削除済み提案・一時的なエラー時は静かにスキップし、一覧全体の表示は継続する
+            print("Failed to load favorite proposal \(entry.proposalId):", error)
+            return nil
+          }
+        }
+      }
+      var results: [ResolvedFavorite] = []
+      for await item in group {
+        if let item {
+          results.append(item)
+        }
+      }
+      return results
+    }
+    resolvedFavorites = resolved.sorted { $0.entry.addedAt > $1.entry.addedAt }
+  }
+}
+
+private struct ResolvedFavorite: Identifiable {
+  let entry: FavoriteEntry
+  let proposal: SwiftEvolution
+  var id: String { entry.id }
+}
+
+#Preview {
+  NavigationStack {
+    FavoritesScreen()
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -12,6 +12,7 @@ struct ProposalListScreen: View {
   @Environment(\.quizRepository) var quizRepository
   @Environment(\.testingQuizRepository) var testingQuizRepository
   @Environment(\.streakRepository) var streakRepository
+  @Environment(\.favoriteRepository) var favoriteRepository
   @Environment(\.analytics) var analytics
   @Environment(DeepLinkRouter.self) private var router
   @State private var proposals: AsyncProposals = .idle
@@ -23,6 +24,7 @@ struct ProposalListScreen: View {
   @State private var showsSetting: Bool = false
   @State private var quizProgresses: [String: ProposalProgress] = [:]
   @State private var isLoadingProgress: Bool = false
+  @State private var favoriteProposalIds: Set<String> = []
   @State private var searchText: String = ""
   @State private var debouncedSearchText: String = ""
   @State private var sortOrder: ProposalSortOrder = .descending
@@ -137,6 +139,9 @@ struct ProposalListScreen: View {
       // 進捗情報を読み込む
       await loadQuizProgresses()
 
+      // お気に入り状態を読み込む
+      await loadFavorites()
+
       // 今日のチャレンジを読み込む（Swift Evolution タブのみ）
       if track == .swiftEvolution {
         await loadDailyChallenge()
@@ -208,25 +213,32 @@ struct ProposalListScreen: View {
         }
       }
       ForEach(proposals.content) { proposal in
-        NavigationLink(value: proposal) {
-          VStack(alignment: .leading, spacing: AppSpacing.sm) {
-            HStack {
-              MarkdownText(proposal.title)
-                .font(AppFont.headline)
-              Text(proposal.displayId)
-                .font(AppFont.caption)
-            }
-            MarkdownText(proposal.status ?? "")
-              .font(AppFont.subheadline)
-            MarkdownText(proposal.authors)
-              .font(AppFont.subheadline)
-            MarkdownText(proposal.reviewManager ?? "")
-              .font(AppFont.subheadline)
+        HStack {
+          NavigationLink(value: proposal) {
+            VStack(alignment: .leading, spacing: AppSpacing.sm) {
+              HStack {
+                MarkdownText(proposal.title)
+                  .font(AppFont.headline)
+                Text(proposal.displayId)
+                  .font(AppFont.caption)
+              }
+              MarkdownText(proposal.status ?? "")
+                .font(AppFont.subheadline)
+              MarkdownText(proposal.authors)
+                .font(AppFont.subheadline)
+              MarkdownText(proposal.reviewManager ?? "")
+                .font(AppFont.subheadline)
 
-            if let progress = quizProgresses[proposal.proposalId] {
-              QuizProgressView(progress: progress)
-                .padding(.top, AppSpacing.xs)
+              if let progress = quizProgresses[proposal.proposalId] {
+                QuizProgressView(progress: progress)
+                  .padding(.top, AppSpacing.xs)
+              }
             }
+          }
+          // List内でNavigationLinkを2つ並べると開示矢印が重複しレイアウトが崩れるため、
+          // お気に入りボタンはButtonで実装する
+          FavoriteButton(isFavorite: favoriteProposalIds.contains(proposal.proposalId)) {
+            toggleFavorite(proposal)
           }
         }
         .onAppear {
@@ -264,25 +276,40 @@ struct ProposalListScreen: View {
     .navigationDestination(for: StreakStatsRoute.self) { _ in
       StreakStatsScreen()
     }
+    .navigationDestination(for: FavoritesRoute.self) { _ in
+      FavoritesScreen()
+    }
     .toolbar {
       #if os(iOS)
-        ToolbarItem(placement: .topBarLeading) {
+        ToolbarItemGroup(placement: .topBarLeading) {
           Button {
             showsSetting = true
           } label: {
             Image(systemName: "gearshape")
           }
+          Button {
+            navigationPath.append(FavoritesRoute())
+          } label: {
+            Image(systemName: "bookmark")
+          }
+          .accessibilityLabel("お気に入り")
         }
         ToolbarItem(placement: .topBarTrailing) {
           sortMenu
         }
       #elseif os(macOS)
-        ToolbarItem(placement: .navigation) {
+        ToolbarItemGroup(placement: .navigation) {
           Button {
             showsSetting = true
           } label: {
             Image(systemName: "gearshape")
           }
+          Button {
+            navigationPath.append(FavoritesRoute())
+          } label: {
+            Image(systemName: "bookmark")
+          }
+          .accessibilityLabel("お気に入り")
         }
         ToolbarItem(placement: .primaryAction) {
           sortMenu
@@ -358,6 +385,27 @@ struct ProposalListScreen: View {
     } catch {
       print("Failed to load quiz progresses:", error)
       // エラー時も進捗なしで表示を継続
+    }
+  }
+
+  /// お気に入り状態を読み込む（このタブのtrackに閉じたproposalIdの集合として保持）
+  private func loadFavorites() async {
+    let allFavorites = await favoriteRepository.getAllFavorites()
+    favoriteProposalIds = Set(
+      allFavorites.filter { $0.track == track }.map(\.proposalId))
+  }
+
+  /// お気に入り状態をトグルする。ローカルSetを楽観的に更新してからリポジトリに反映する
+  private func toggleFavorite(_ proposal: SwiftEvolution) {
+    let proposalId = proposal.proposalId
+    let willBeFavorite = !favoriteProposalIds.contains(proposalId)
+    if willBeFavorite {
+      favoriteProposalIds.insert(proposalId)
+    } else {
+      favoriteProposalIds.remove(proposalId)
+    }
+    Task {
+      _ = await favoriteRepository.toggle(proposalId: proposalId, track: track)
     }
   }
 

--- a/ios/se-masked-quiz/Repositories/FavoriteRepository.swift
+++ b/ios/se-masked-quiz/Repositories/FavoriteRepository.swift
@@ -1,0 +1,91 @@
+//
+//  FavoriteRepository.swift
+//  se-masked-quiz
+//
+//  お気に入り登録の記録・判定を担うリポジトリ。SE/ST を横断して一覧表示する要件のため、
+//  QuizRepository のような track 別 namespace 分割ではなく単一リストで一元管理する。
+//
+
+import Foundation
+import SwiftUI
+
+// MARK: - Repository Protocol
+
+/// @mockable
+protocol FavoriteRepository: Actor, Sendable {
+  /// お気に入り状態をトグルし、トグル後の状態（true = 追加済み）を返す
+  func toggle(proposalId: String, track: ProposalTrack) async -> Bool
+
+  /// 指定の提案がお気に入り済みか
+  func isFavorite(proposalId: String, track: ProposalTrack) async -> Bool
+
+  /// 全お気に入りエントリを取得
+  func getAllFavorites() async -> [FavoriteEntry]
+}
+
+// MARK: - Repository Implementation
+
+actor FavoriteRepositoryImpl: FavoriteRepository {
+  private let userDefaults: UserDefaults
+
+  private static let favoritesKey = "favorite_entries"
+
+  init(userDefaults: UserDefaults = .standard) {
+    self.userDefaults = userDefaults
+  }
+
+  func toggle(proposalId: String, track: ProposalTrack) async -> Bool {
+    var entries = loadEntries()
+    if let index = entries.firstIndex(where: {
+      $0.proposalId == proposalId && $0.track == track
+    }) {
+      entries.remove(at: index)
+      saveEntries(entries)
+      return false
+    } else {
+      entries.append(FavoriteEntry(proposalId: proposalId, track: track, addedAt: Date()))
+      saveEntries(entries)
+      return true
+    }
+  }
+
+  func isFavorite(proposalId: String, track: ProposalTrack) async -> Bool {
+    loadEntries().contains { $0.proposalId == proposalId && $0.track == track }
+  }
+
+  func getAllFavorites() async -> [FavoriteEntry] {
+    loadEntries()
+  }
+
+  // MARK: - Private Helpers
+
+  private func loadEntries() -> [FavoriteEntry] {
+    guard let data = userDefaults.data(forKey: Self.favoritesKey),
+      let entries = try? JSONDecoder().decode([FavoriteEntry].self, from: data)
+    else {
+      return []
+    }
+    return entries
+  }
+
+  private func saveEntries(_ entries: [FavoriteEntry]) {
+    if let encoded = try? JSONEncoder().encode(entries) {
+      userDefaults.set(encoded, forKey: Self.favoritesKey)
+    }
+  }
+}
+
+// MARK: - Environment
+
+extension FavoriteRepositoryImpl: EnvironmentKey {
+  static var defaultValue: any FavoriteRepository {
+    FavoriteRepositoryImpl()
+  }
+}
+
+extension EnvironmentValues {
+  var favoriteRepository: any FavoriteRepository {
+    get { self[FavoriteRepositoryImpl.self] }
+    set { self[FavoriteRepositoryImpl.self] = newValue }
+  }
+}

--- a/ios/se-masked-quizTests/FavoriteRepositoryTests.swift
+++ b/ios/se-masked-quizTests/FavoriteRepositoryTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("FavoriteRepository Tests")
+struct FavoriteRepositoryTests {
+
+  // MARK: - Helpers
+
+  private func makeSUT() -> FavoriteRepositoryImpl {
+    let suiteName = "favorite-test-\(UUID().uuidString)"
+    let defaults = UserDefaults(suiteName: suiteName)!
+    defaults.removePersistentDomain(forName: suiteName)
+    return FavoriteRepositoryImpl(userDefaults: defaults)
+  }
+
+  // MARK: - Tests
+
+  @Test("トグルするとお気に入りに追加される")
+  func toggleAdds() async {
+    let sut = makeSUT()
+    let result = await sut.toggle(proposalId: "0001", track: .swiftEvolution)
+    #expect(result == true)
+    let isFavorite = await sut.isFavorite(proposalId: "0001", track: .swiftEvolution)
+    #expect(isFavorite == true)
+  }
+
+  @Test("再度トグルすると解除される")
+  func toggleTwiceRemoves() async {
+    let sut = makeSUT()
+    _ = await sut.toggle(proposalId: "0001", track: .swiftEvolution)
+    let result = await sut.toggle(proposalId: "0001", track: .swiftEvolution)
+    #expect(result == false)
+    let isFavorite = await sut.isFavorite(proposalId: "0001", track: .swiftEvolution)
+    #expect(isFavorite == false)
+  }
+
+  @Test("未登録の提案はisFavoriteがfalse")
+  func isFavoriteDefaultsFalse() async {
+    let sut = makeSUT()
+    let isFavorite = await sut.isFavorite(proposalId: "9999", track: .swiftEvolution)
+    #expect(isFavorite == false)
+  }
+
+  @Test("getAllFavoritesが全エントリを返す")
+  func getAllFavoritesReturnsEntries() async {
+    let sut = makeSUT()
+    _ = await sut.toggle(proposalId: "0001", track: .swiftEvolution)
+    _ = await sut.toggle(proposalId: "0002", track: .swiftEvolution)
+    let all = await sut.getAllFavorites()
+    #expect(all.count == 2)
+    #expect(Set(all.map(\.proposalId)) == ["0001", "0002"])
+  }
+
+  @Test("SE/STで同一proposalIdをそれぞれトグルしても独立して動作する")
+  func seAndStAreIndependent() async {
+    let sut = makeSUT()
+    _ = await sut.toggle(proposalId: "0001", track: .swiftEvolution)
+    let stFavoriteBefore = await sut.isFavorite(proposalId: "0001", track: .swiftTesting)
+    #expect(stFavoriteBefore == false)
+
+    _ = await sut.toggle(proposalId: "0001", track: .swiftTesting)
+    let seFavorite = await sut.isFavorite(proposalId: "0001", track: .swiftEvolution)
+    let stFavoriteAfter = await sut.isFavorite(proposalId: "0001", track: .swiftTesting)
+    #expect(seFavorite == true)
+    #expect(stFavoriteAfter == true)
+
+    let all = await sut.getAllFavorites()
+    #expect(all.count == 2)
+  }
+}

--- a/ios/se-masked-quizTests/Generated/GeneratedMocks.swift
+++ b/ios/se-masked-quizTests/Generated/GeneratedMocks.swift
@@ -261,6 +261,68 @@ final actor QuizRepositoryMock: QuizRepository, @unchecked Sendable {
     }
 }
 
+final actor FavoriteRepositoryMock: FavoriteRepository, @unchecked Sendable {
+    init() { }
+
+
+    private let toggleState = MockoloMutex(MockoloHandlerState<Never, @Sendable (String, ProposalTrack) async -> Bool>())
+    nonisolated var toggleCallCount: Int {
+        return toggleState.withLock(\.callCount)
+    }
+    nonisolated var toggleHandler: (@Sendable (String, ProposalTrack) async -> Bool)? {
+        get { toggleState.withLock(\.handler) }
+        set { toggleState.withLock { $0.handler = newValue } }
+    }
+    func toggle(proposalId: String, track: ProposalTrack) async -> Bool {
+        let toggleHandler = toggleState.withLock { state in
+            state.callCount += 1
+            return state.handler
+        }
+        if let toggleHandler = toggleHandler {
+            return await toggleHandler(proposalId, track)
+        }
+        return false
+    }
+
+    private let isFavoriteState = MockoloMutex(MockoloHandlerState<Never, @Sendable (String, ProposalTrack) async -> Bool>())
+    nonisolated var isFavoriteCallCount: Int {
+        return isFavoriteState.withLock(\.callCount)
+    }
+    nonisolated var isFavoriteHandler: (@Sendable (String, ProposalTrack) async -> Bool)? {
+        get { isFavoriteState.withLock(\.handler) }
+        set { isFavoriteState.withLock { $0.handler = newValue } }
+    }
+    func isFavorite(proposalId: String, track: ProposalTrack) async -> Bool {
+        let isFavoriteHandler = isFavoriteState.withLock { state in
+            state.callCount += 1
+            return state.handler
+        }
+        if let isFavoriteHandler = isFavoriteHandler {
+            return await isFavoriteHandler(proposalId, track)
+        }
+        return false
+    }
+
+    private let getAllFavoritesState = MockoloMutex(MockoloHandlerState<Never, @Sendable () async -> [FavoriteEntry]>())
+    nonisolated var getAllFavoritesCallCount: Int {
+        return getAllFavoritesState.withLock(\.callCount)
+    }
+    nonisolated var getAllFavoritesHandler: (@Sendable () async -> [FavoriteEntry])? {
+        get { getAllFavoritesState.withLock(\.handler) }
+        set { getAllFavoritesState.withLock { $0.handler = newValue } }
+    }
+    func getAllFavorites() async -> [FavoriteEntry] {
+        let getAllFavoritesHandler = getAllFavoritesState.withLock { state in
+            state.callCount += 1
+            return state.handler
+        }
+        if let getAllFavoritesHandler = getAllFavoritesHandler {
+            return await getAllFavoritesHandler()
+        }
+        return [FavoriteEntry]()
+    }
+}
+
 fileprivate func warnIfNotSendable<each T>(function: String = #function, _: repeat each T) {
     print("At \(function), the captured arguments are not Sendable, it is not concurrency-safe.")
 }


### PR DESCRIPTION
## 概要

提案を後で見返せるよう、一覧の各行にブックマークボタンを追加し、SE/ST両トラックを横断して閲覧できる専用のお気に入り画面を新設しました。

**⚠️ このPRは #53 (デザインシステム構築) をベースにしています。** `SemanticColor`等のデザイントークンに依存するため、base branchを`feature/design-system-foundation`に設定しています。#53マージ後にbase branchをmainに変更します。

## 背景・目的

- 気になる提案を後で見返したいというニーズに対応
- SE/ST横断で一箇所にまとめて確認できるようにしたい

## 主要な変更点

### データ層
- `FavoriteEntry`: proposalId+track+addedAtを持つエントリモデル。`proposalId`はSE/ST間で衝突しうるbare 4桁のため、`track`を保持して個別に区別する
- `FavoriteRepository`: `StreakRepository`と同じactor+UserDefaultsパターンを踏襲。お気に入り一覧はSE/ST横断表示が要件のため、`QuizRepository`のようなtrack別namespace分割ではなく単一リストで一元管理する

### UI
- `FavoriteButton` (`DesignSystem/Components/`): `bookmark`/`bookmark.fill`をトグルする軽量ボタン
- `ProposalListScreen`: 一覧の各行に`FavoriteButton`を追加。既存の「List内で`NavigationLink`を2つ並べると開示矢印が重複してレイアウトが崩れる」という教訓を踏まえ、`Button`ベースで実装。ツールバーにお気に入り画面への導線を追加(iOS/macOS両対応)
- `FavoritesScreen`: SE/ST横断のお気に入り一覧画面。`TaskGroup`で並行して提案を解決し、削除済み等で取得できないエントリは静かにスキップする。空状態は`ContentUnavailableView`

### テスト
- `FavoriteRepositoryTests`: toggle/isFavorite/getAllFavorites、およびSE/STで同一proposalId(例: 両方"0001")を個別にお気に入りにしても互いに干渉しないことを検証

## テスト

- [x] iOS/macOS双方でビルド成功
- [x] 全ユニットテスト成功(`xcodebuild test`)
- [x] `swift-complexity --threshold 10` 成功(閾値超過なし)
- [x] シミュレータで表示確認。実装時に「未登録アイコンがAccentColorの影響でオレンジがかる」問題を発見し、`Color.secondary`の明示指定で修正済み
- [ ] 実機/シミュレータでのタップ操作によるトグル・画面遷移の確認は`idb`未インストールのため未実施(ビルド・静止画面確認のみ)

## レビューポイント

- `FavoriteRepository`が`QuizRepository`のtrack別namespace分割パターンを踏襲せず、単一リストで一元管理している点(お気に入り一覧のSE/ST横断表示という要件のため)
- `FavoritesScreen`で削除済み提案を静かにスキップする設計(専用の「削除された提案」UIは過剰と判断し設けていません)

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->