### PR TITLE
fastlane: build_appがIPAをエクスポートしない不具合を修正

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -17,6 +17,7 @@ DerivedData/
 !default.perspectivev3
 *.hmap
 *.ipa
+*.app
 *.dSYM.zip
 *.dSYM
 

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -53,7 +53,7 @@ platform :ios do
     build_app(
       project: "se-masked-quiz.xcodeproj",
       scheme: "se-masked-quiz",
-      destination: "generic/platform=iOS",
+      sdk: "iphoneos",
       export_method: "app-store",
       export_options: {
         method: "app-store",

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -73,8 +73,8 @@ platform :ios do
   lane :submit_for_review do
     deliver(
       app_identifier: ENV["APP_IDENTIFIER"],
-      app_version: "1.5.0",
-      build_number: "6",
+      app_version: "1.6.0",
+      build_number: "7",
       skip_screenshots: true,
       skip_binary_upload: true,
       skip_app_version_update: false,


### PR DESCRIPTION
## 概要

`release_testflight`レーンで`build_app`(gym)がアーカイブには成功するもののIPAへのexportステップを実行せず、`upload_to_testflight`が`No ipa or pkg file given`で失敗する不具合を修正しました。あわせて、TestFlightへのアップロードが完了したバージョン1.6.0(build 7)に合わせて`submit_for_review`レーンのバージョン指定を更新しました。

## 背景・原因

1回目の実行: `destination: "generic/platform=iOS"`を指定した状態で`build_app`を実行したところ、archiveとdSYM圧縮までは成功したが、`-exportArchive`のログが一切出力されないままIPA未生成で`upload_to_testflight`に進み失敗（`No ipa or pkg file given`）。

2回目の実行: `destination`を削除して再実行したところ、今度は**macOS向け**にUniversal Binaryがビルドされ(`sdk: MacOSX26.5.sdk`)、Mac用の署名証明書が無くexportに失敗（`No signing certificate "Mac Installer Distribution" found`）。このプロジェクトは`SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx"`のマルチプラットフォーム対応(直近のデザインシステム構築PRでLiquid Glass対応のため追加)のため、`destination`を指定しないとgymがmacOSをデフォルト選択してしまうことが判明。

3回目の実行: `sdk: "iphoneos"`を明示指定したところ、正しくiOS向けにarchive・IPA export・TestFlightへのアップロードまで成功。

## 変更内容

- `ios/fastlane/Fastfile`: `build_app`の`destination: "generic/platform=iOS"`を`sdk: "iphoneos"`に置き換え
- `ios/.gitignore`: gymの出力先(`output_directory: "."`)に生成される`*.app`ディレクトリが未追跡だったため追加
- `ios/fastlane/Fastfile`: 修正確認のため一時的に追加していた`check_testflight_status`レーンを削除
- `ios/fastlane/Fastfile`: `submit_for_review`レーンの`app_version`/`build_number`を`1.5.0`/`6`から、TestFlightアップロード済みの`1.6.0`/`7`へ更新

## テスト

- [x] `ruby -c ios/fastlane/Fastfile` で構文確認
- [x] 実際に`bundle exec fastlane release_testflight`を実行し、`build_app`(879秒)・`upload_to_testflight`(103秒)ともに成功。TestFlightへのアップロード完了を確認済み（バージョン1.6.0 build 7）
- [x] `bundle exec fastlane check_testflight_status`（削除前に一時実行）で、App Store Connect側がbuild 7を最新ビルドとして認識済みであることを確認

## レビューポイント

- `destination`と`sdk`を両方指定せず`sdk`のみにした点（両方指定した場合の挙動は未検証）

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->
