### PR TITLE
UI再デザイン: 一覧・前提提案・依存グラフの視認性改善 + 学習記録タブの新設

### DIFF
--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphModels.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphModels.swift
@@ -26,8 +26,18 @@ struct GraphLayout {
 }
 
 /// root を中心に置き、hop k のノードを半径 k·ringSpacing の同心円上へ等間隔配置する決定論レイアウト。
+///
+/// ノード数がリング周長に対して多い場合はノードチップ同士が重なって読めなくなるため、
+/// 弧長が `minArcSpacing` を下回らないよう半径を広げ、さらに偶奇 index で内外リングへ
+/// 振り分けて（スタッガー）角密度を実質半分にする。混雑していないリングは従来配置のまま。
 enum RadialLayout {
-  static func compute(nodes: [GraphNode], center: CGPoint, ringSpacing: CGFloat) -> GraphLayout {
+  static func compute(
+    nodes: [GraphNode],
+    center: CGPoint,
+    ringSpacing: CGFloat,
+    minArcSpacing: CGFloat = 100,
+    staggerOffset: CGFloat = 60
+  ) -> GraphLayout {
     var positions: [String: CGPoint] = [:]
     let byHop = Dictionary(grouping: nodes, by: \.hop)
     for (hop, group) in byHop {
@@ -37,14 +47,21 @@ enum RadialLayout {
         }
         continue
       }
-      let radius = CGFloat(hop) * ringSpacing
+      let baseRadius = CGFloat(hop) * ringSpacing
       let sorted = group.sorted { $0.id < $1.id }
       let count = max(sorted.count, 1)
+      let requiredRadius = CGFloat(count) * minArcSpacing / (2 * .pi)
+      let isCrowded = requiredRadius > baseRadius
+      let radius = max(baseRadius, requiredRadius)
       for (index, node) in sorted.enumerated() {
         let theta = (2 * CGFloat.pi / CGFloat(count)) * CGFloat(index) - CGFloat.pi / 2
+        let staggeredRadius =
+          isCrowded
+          ? radius + (index.isMultiple(of: 2) ? -staggerOffset / 2 : staggerOffset / 2)
+          : radius
         positions[node.id] = CGPoint(
-          x: center.x + radius * cos(theta),
-          y: center.y + radius * sin(theta)
+          x: center.x + staggeredRadius * cos(theta),
+          y: center.y + staggeredRadius * sin(theta)
         )
       }
     }

--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphScreen.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphScreen.swift
@@ -26,7 +26,7 @@ struct DependencyGraphScreen: View {
     GeometryReader { proxy in
       let center = CGPoint(x: proxy.size.width / 2, y: proxy.size.height / 2)
       ZStack {
-        edgeCanvas(center: center)
+        edgeCanvas(center: center, selectedId: selectedNode?.id)
         nodeViews(center: center)
       }
       .scaleEffect(scale)
@@ -49,6 +49,7 @@ struct DependencyGraphScreen: View {
         MagnificationGesture().onChanged { scale = min(max(0.5, $0), 2.5) }
       )
       .overlay(alignment: .top) { topBanner }
+      .overlay(alignment: .topTrailing) { legendAndReset }
       .overlay(alignment: .bottom) {
         if let node = selectedNode {
           selectionBar(node)
@@ -69,18 +70,64 @@ struct DependencyGraphScreen: View {
 
   // MARK: - Subviews
 
-  private func edgeCanvas(center: CGPoint) -> some View {
+  /// エッジを矢印付きで描画する。選択ノードに接続するエッジは後から accent 色で上書きして強調する。
+  private func edgeCanvas(center: CGPoint, selectedId: String?) -> some View {
     Canvas { context, _ in
-      for edge in viewModel.edges {
-        guard let from = viewModel.layout.positions[edge.from],
-          let to = viewModel.layout.positions[edge.to]
-        else { continue }
-        var path = Path()
-        path.move(to: screenPoint(from, center: center))
-        path.addLine(to: screenPoint(to, center: center))
-        context.stroke(path, with: .color(.secondary.opacity(0.4)), lineWidth: 1)
+      let highlighted = viewModel.edges.filter {
+        $0.from == selectedId || $0.to == selectedId
+      }
+      let normal = viewModel.edges.filter {
+        $0.from != selectedId && $0.to != selectedId
+      }
+      for edge in normal {
+        drawEdge(edge, in: &context, center: center, color: .secondary.opacity(0.35), lineWidth: 1)
+      }
+      for edge in highlighted {
+        drawEdge(edge, in: &context, center: center, color: .accentColor, lineWidth: 2)
       }
     }
+  }
+
+  /// from→to の線分と、toノード手前に「参照先（先に読む提案）」方向を示す三角形の矢印を描く。
+  private func drawEdge(
+    _ edge: GraphEdge,
+    in context: inout GraphicsContext,
+    center: CGPoint,
+    color: Color,
+    lineWidth: CGFloat
+  ) {
+    guard let fromPos = viewModel.layout.positions[edge.from],
+      let toPos = viewModel.layout.positions[edge.to]
+    else { return }
+    let from = screenPoint(fromPos, center: center)
+    let to = screenPoint(toPos, center: center)
+    let dx = to.x - from.x
+    let dy = to.y - from.y
+    let length = hypot(dx, dy)
+    // ノードチップに矢印が潜り込まないよう手前で止める
+    let nodeMargin: CGFloat = 36
+    guard length > nodeMargin else { return }
+    let ux = dx / length
+    let uy = dy / length
+    let tip = CGPoint(x: to.x - ux * nodeMargin, y: to.y - uy * nodeMargin)
+
+    var line = Path()
+    line.move(to: from)
+    line.addLine(to: tip)
+    context.stroke(line, with: .color(color), lineWidth: lineWidth)
+
+    let arrowLength: CGFloat = 8
+    let arrowHalfWidth: CGFloat = 4.5
+    let base = CGPoint(x: tip.x - ux * arrowLength, y: tip.y - uy * arrowLength)
+    let perp = CGPoint(x: -uy, y: ux)
+    var arrow = Path()
+    arrow.move(to: tip)
+    arrow.addLine(
+      to: CGPoint(x: base.x + perp.x * arrowHalfWidth, y: base.y + perp.y * arrowHalfWidth))
+    arrow.addLine(
+      to: CGPoint(x: base.x - perp.x * arrowHalfWidth, y: base.y - perp.y * arrowHalfWidth))
+    arrow.closeSubpath()
+    context.fill(arrow, with: .color(color))
   }
 
   private func nodeViews(center: CGPoint) -> some View {
@@ -112,6 +159,47 @@ struct DependencyGraphScreen: View {
         .glassCard(cornerRadius: 999)
         .padding(.top, 8)
     }
+  }
+
+  /// 凡例と、パン/ズーム変形時のみ出す表示リセットボタン。
+  /// 下部は選択バーと重なるため、まとめて右上に置く。
+  private var legendAndReset: some View {
+    VStack(alignment: .trailing, spacing: AppSpacing.sm) {
+      VStack(alignment: .leading, spacing: AppSpacing.xs) {
+        HStack(spacing: AppSpacing.xs) {
+          Circle()
+            .fill(Color.accentColor)
+            .frame(width: 8, height: 8)
+          Text("現在の提案")
+        }
+        HStack(spacing: AppSpacing.xs) {
+          Image(systemName: "arrow.right")
+          Text("先に読む提案へ")
+        }
+      }
+      .font(AppFont.caption2)
+      .foregroundStyle(.secondary)
+      .padding(AppSpacing.sm)
+      .glassCard(cornerRadius: AppRadius.medium)
+
+      if scale != 1 || committedOffset != .zero {
+        Button {
+          withAnimation(.snappy) {
+            scale = 1
+            committedOffset = .zero
+            dragOffset = .zero
+          }
+        } label: {
+          Image(systemName: "arrow.counterclockwise")
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .glassCard(cornerRadius: 999)
+        .accessibilityLabel("表示をリセット")
+      }
+    }
+    .padding(.top, AppSpacing.sm)
+    .padding(.trailing, AppSpacing.md)
   }
 
   @ViewBuilder
@@ -177,32 +265,45 @@ struct DependencyGraphScreen: View {
 }
 
 /// グラフ上の1ノード（提案番号 + 短縮タイトル）。
+/// エッジが下を通るため背景は不透明にし、rootはaccent塗り+白文字で最も目立たせる。
 private struct NodeChipView: View {
   let node: GraphNode
   let isRoot: Bool
   let isSelected: Bool
 
-  @ScaledMetric(relativeTo: .caption2) private var titleFontSize: CGFloat = 9
-
   var body: some View {
     VStack(spacing: 2) {
-      Text("#\(Int(node.id) ?? 0)")
+      Text("SE-\(node.id)")
         .font(AppFont.caption2)
         .bold()
       Text(node.title)
-        .font(.system(size: titleFontSize))
-        .lineLimit(1)
-        .frame(maxWidth: 90)
+        .font(AppFont.caption2)
+        .lineLimit(2)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 120)
     }
-    .padding(.horizontal, 8)
+    .foregroundStyle(isRoot ? Color.white : Color.primary)
+    .padding(.horizontal, AppSpacing.sm)
     .padding(.vertical, 6)
-    .background(
-      RoundedRectangle(cornerRadius: 8)
-        .fill(isRoot ? Color.accentColor.opacity(0.25) : Color.secondary.opacity(0.15))
-    )
+    .background {
+      ZStack {
+        RoundedRectangle(cornerRadius: AppRadius.medium)
+          .fill(.background)
+        RoundedRectangle(cornerRadius: AppRadius.medium)
+          .fill(isRoot ? AnyShapeStyle(Color.accentColor) : AnyShapeStyle(.fill.secondary))
+      }
+    }
     .overlay(
-      RoundedRectangle(cornerRadius: 8)
-        .stroke(isSelected ? Color.accentColor : Color.clear, lineWidth: 2)
+      RoundedRectangle(cornerRadius: AppRadius.medium)
+        .stroke(strokeStyle, lineWidth: isSelected ? 2 : 1)
     )
+  }
+
+  /// 選択枠は非rootならaccent、root（accent塗り）上では白で示す。非選択の非rootは薄い輪郭のみ。
+  private var strokeStyle: AnyShapeStyle {
+    if isSelected {
+      return AnyShapeStyle(isRoot ? Color.white : Color.accentColor)
+    }
+    return isRoot ? AnyShapeStyle(.clear) : AnyShapeStyle(.separator)
   }
 }

--- a/ios/se-masked-quiz/GraphFeature/DependencyGraphViewModel.swift
+++ b/ios/se-masked-quiz/GraphFeature/DependencyGraphViewModel.swift
@@ -30,7 +30,7 @@ final class DependencyGraphViewModel: ObservableObject {
   init(
     maxHops: Int = 1,
     maxNodes: Int = 40,
-    ringSpacing: CGFloat = 140,
+    ringSpacing: CGFloat = 160,
     outgoingFetch: @escaping OutgoingFetch = { ids in
       let refs = try await ProposalReferenceRepository().fetchOutgoing(fromProposalIds: ids)
       return refs.map { GraphEdge(from: $0.fromProposalId, to: $0.toProposalId) }

--- a/ios/se-masked-quiz/Models/AppTab.swift
+++ b/ios/se-masked-quiz/Models/AppTab.swift
@@ -1,0 +1,12 @@
+//
+//  AppTab.swift
+//  se-masked-quiz
+//
+//  アプリのトップレベルタブ。SE/STのトラックタブに加え、
+//  トラック横断データ（ストリーク・正答率）を扱う学習記録タブを独立させる。
+//
+
+enum AppTab: Hashable {
+  case track(ProposalTrack)
+  case stats
+}

--- a/ios/se-masked-quiz/Models/ProposalStatus.swift
+++ b/ios/se-masked-quiz/Models/ProposalStatus.swift
@@ -1,0 +1,94 @@
+//
+//  ProposalStatus.swift
+//  se-masked-quiz
+//
+//  提案のstatus（Markdown文字列、例: "**Implemented (Swift 5.9)**"）を
+//  バッジ表示用のカテゴリ・短ラベル・色へ写像する。
+//
+
+import SwiftUI
+
+enum ProposalStatus: Equatable, Sendable {
+  case implemented(version: String?)
+  case partiallyImplemented
+  case accepted
+  case activeReview
+  case previewing
+  case returned
+  case rejected
+  case withdrawn
+  case unknown(text: String)
+
+  /// Markdown装飾・括弧書き・リンクを除いた本文で判定する。
+  /// "Partially implemented" が "implemented" を含む等の包含関係があるため判定順序を変えないこと。
+  static func parse(_ raw: String?) -> ProposalStatus {
+    guard let raw else { return .unknown(text: "") }
+    let cleaned = cleanedText(raw)
+    let lowered = cleaned.lowercased()
+    let rules: [(keywords: [String], status: ProposalStatus)] = [
+      (["partially"], .partiallyImplemented),
+      (["implemented"], .implemented(version: swiftVersion(in: raw))),
+      (["accepted"], .accepted),
+      (["active review"], .activeReview),
+      (["previewing"], .previewing),
+      (["rejected"], .rejected),
+      (["returned"], .returned),
+      (["withdrawn", "expired"], .withdrawn),
+    ]
+    for rule in rules where rule.keywords.contains(where: lowered.contains) {
+      return rule.status
+    }
+    return .unknown(text: cleaned)
+  }
+
+  var label: String {
+    switch self {
+    case .implemented(let version): return Self.implementedLabel(version)
+    case .unknown(let text): return text
+    default: return simpleLabel
+    }
+  }
+
+  private static func implementedLabel(_ version: String?) -> String {
+    version.map { "Swift \($0)" } ?? "Implemented"
+  }
+
+  /// 連想値を持たないcaseの固定ラベル。1つのswitchに全caseを並べると
+  /// 循環的複雑度が閾値(10)を超えるため label から分割している
+  private var simpleLabel: String {
+    switch self {
+    case .partiallyImplemented: return "Partially Implemented"
+    case .accepted: return "Accepted"
+    case .activeReview: return "Active Review"
+    case .previewing: return "Previewing"
+    case .returned: return "Returned"
+    case .rejected: return "Rejected"
+    case .withdrawn: return "Withdrawn"
+    default: return ""
+    }
+  }
+
+  var color: Color {
+    switch self {
+    case .implemented: return SemanticColor.correct
+    case .partiallyImplemented, .accepted: return SemanticColor.inProgress
+    case .activeReview, .previewing, .returned: return SemanticColor.warning
+    case .rejected: return SemanticColor.incorrect
+    case .withdrawn, .unknown: return SemanticColor.neutral
+    }
+  }
+
+  /// "**" 装飾を除き、最初の "(" / "[" 以降（レビュー期間・Rationaleリンク等）を落とす
+  private static func cleanedText(_ raw: String) -> String {
+    var text = raw.replacingOccurrences(of: "**", with: "")
+    if let cutIndex = text.firstIndex(where: { $0 == "(" || $0 == "[" }) {
+      text = String(text[..<cutIndex])
+    }
+    return text.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private static func swiftVersion(in raw: String) -> String? {
+    guard let match = raw.firstMatch(of: /\(Swift ([0-9][0-9.]*)\)/) else { return nil }
+    return String(match.1)
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/FavoritesScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/FavoritesScreen.swift
@@ -21,16 +21,7 @@ struct FavoritesScreen: View {
     List {
       ForEach(resolvedFavorites) { resolved in
         NavigationLink(value: resolved.proposal) {
-          VStack(alignment: .leading, spacing: AppSpacing.sm) {
-            HStack {
-              MarkdownText(resolved.proposal.title)
-                .font(AppFont.headline)
-              Text(resolved.proposal.displayId)
-                .font(AppFont.caption)
-            }
-            MarkdownText(resolved.proposal.authors)
-              .font(AppFont.subheadline)
-          }
+          ProposalRowView(proposal: resolved.proposal)
         }
       }
     }

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -195,45 +195,18 @@ struct ProposalListScreen: View {
     List {
       if let daily = dailyProposal {
         Section {
-          HStack {
-            NavigationLink(value: daily) {
-              DailyChallengeCard(proposal: daily)
-            }
-            // List内でNavigationLinkを2つ並べると開示矢印(chevron)が重複し、
-            // 行の幅計算が崩れてDailyChallengeCard側が圧縮されてしまうためButtonで代替する
-            Button {
-              navigationPath.append(StreakStatsRoute())
-            } label: {
-              Image(systemName: "chart.bar.xaxis")
-                .font(.title3)
-                .foregroundStyle(.secondary)
-            }
-            .buttonStyle(.borderless)
+          NavigationLink(value: daily) {
+            DailyChallengeCard(proposal: daily)
           }
         }
       }
       ForEach(proposals.content) { proposal in
         HStack {
           NavigationLink(value: proposal) {
-            VStack(alignment: .leading, spacing: AppSpacing.sm) {
-              HStack {
-                MarkdownText(proposal.title)
-                  .font(AppFont.headline)
-                Text(proposal.displayId)
-                  .font(AppFont.caption)
-              }
-              MarkdownText(proposal.status ?? "")
-                .font(AppFont.subheadline)
-              MarkdownText(proposal.authors)
-                .font(AppFont.subheadline)
-              MarkdownText(proposal.reviewManager ?? "")
-                .font(AppFont.subheadline)
-
-              if let progress = quizProgresses[proposal.proposalId] {
-                QuizProgressView(progress: progress)
-                  .padding(.top, AppSpacing.xs)
-              }
-            }
+            ProposalRowView(
+              proposal: proposal,
+              progress: quizProgresses[proposal.proposalId]
+            )
           }
           // List内でNavigationLinkを2つ並べると開示矢印が重複しレイアウトが崩れるため、
           // お気に入りボタンはButtonで実装する
@@ -241,6 +214,11 @@ struct ProposalListScreen: View {
             toggleFavorite(proposal)
           }
         }
+        .listRowInsets(
+          EdgeInsets(
+            top: AppSpacing.sm, leading: AppSpacing.lg,
+            bottom: AppSpacing.sm, trailing: AppSpacing.md)
+        )
         .onAppear {
           guard let proposalIndex = proposals.content.firstIndex(of: proposal) else {
             return
@@ -272,9 +250,6 @@ struct ProposalListScreen: View {
         rootProposalId: route.rootProposalId,
         rootTitle: route.rootTitle
       )
-    }
-    .navigationDestination(for: StreakStatsRoute.self) { _ in
-      StreakStatsScreen()
     }
     .navigationDestination(for: FavoritesRoute.self) { _ in
       FavoritesScreen()

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -56,30 +56,25 @@ struct ProposalQuizView: View {
           }) {
             Image(systemName: "arrow.counterclockwise")
               .foregroundStyle(SemanticColor.incorrect)
+              .frame(minWidth: 44, minHeight: 44)
+              .contentShape(Rectangle())
           }
+          .accessibilityLabel("クイズをリセット")
         }
-        .padding()
+        .padding(.horizontal)
+        .padding(.vertical, AppSpacing.sm)
       }
 
       if !relatedProposals.isEmpty {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("先に読むと理解しやすい提案")
-            .font(.caption)
-            .foregroundColor(.secondary)
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+          Label("先に読むと理解しやすい提案", systemImage: "book")
+            .font(AppFont.subheadline.weight(.semibold))
             .padding(.horizontal)
           ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
+            HStack(spacing: AppSpacing.sm) {
               ForEach(relatedProposals) { related in
                 NavigationLink(value: related) {
-                  AppBadge(style: .subtle(.secondary)) {
-                    HStack(spacing: 4) {
-                      Text("#\(Int(related.proposalId) ?? 0)")
-                        .bold()
-                      MarkdownText(related.title)
-                        .lineLimit(1)
-                    }
-                    .font(AppFont.caption2)
-                  }
+                  RelatedProposalCard(proposal: related)
                 }
                 .buttonStyle(.plain)
               }
@@ -87,7 +82,7 @@ struct ProposalQuizView: View {
             .padding(.horizontal)
           }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, AppSpacing.sm)
       }
 
       DefaultWebView(

--- a/ios/se-masked-quiz/ProposalFeature/ProposalRowView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalRowView.swift
@@ -1,0 +1,75 @@
+//
+//  ProposalRowView.swift
+//  se-masked-quiz
+//
+//  提案一覧・お気に入り一覧で共用する行。
+//  ID/ステータスをバッジで示し、タイトル+コンパクト進捗の3行以内に収めて情報密度を上げる。
+//  authors/reviewManagerは提案本文側に記載があるため行には出さない。
+//
+
+import SwiftUI
+
+struct ProposalRowView: View {
+  let proposal: SwiftEvolution
+  var progress: ProposalProgress?
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: AppSpacing.sm) {
+      HStack(spacing: AppSpacing.sm) {
+        AppBadge(text: proposal.displayId, style: .subtle(.accentColor))
+        if let status = parsedStatus {
+          AppBadge(text: status.label, style: .subtle(status.color))
+        }
+      }
+      MarkdownText(proposal.title)
+        .font(AppFont.headline)
+        .lineLimit(2)
+      if let progress {
+        QuizProgressView(progress: progress, compact: true)
+      }
+    }
+  }
+
+  /// status未設定やパース結果が空ラベルの場合はバッジを出さない
+  private var parsedStatus: ProposalStatus? {
+    guard proposal.status != nil else { return nil }
+    let parsed = ProposalStatus.parse(proposal.status)
+    return parsed.label.isEmpty ? nil : parsed
+  }
+}
+
+// MARK: - Previews
+
+private func previewProposal(status: String?, progress: Bool = false) -> SwiftEvolution {
+  SwiftEvolution(
+    id: "1",
+    proposalId: "0401",
+    title: "Remove Actor Isolation Inference caused by Property Wrappers",
+    reviewManager: nil,
+    status: status,
+    authors: "[Author](https://example.com)",
+    content: ""
+  )
+}
+
+#Preview("Implemented + 進捗あり") {
+  List {
+    ProposalRowView(
+      proposal: previewProposal(status: "**Implemented (Swift 5.9)**"),
+      progress: ProposalProgress(
+        proposalId: "0401", answeredCount: 5, totalCount: 10, correctCount: 4)
+    )
+  }
+}
+
+#Preview("各ステータス") {
+  List {
+    ProposalRowView(proposal: previewProposal(status: "**Implemented (Swift 5.9)**"))
+    ProposalRowView(proposal: previewProposal(status: "**Accepted**"))
+    ProposalRowView(proposal: previewProposal(status: "**Active review (March 1...11, 2024)**"))
+    ProposalRowView(proposal: previewProposal(status: "**Rejected**"))
+    ProposalRowView(proposal: previewProposal(status: "**Returned for revision**"))
+    ProposalRowView(proposal: previewProposal(status: "**Withdrawn**"))
+    ProposalRowView(proposal: previewProposal(status: nil))
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/QuizProgressView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizProgressView.swift
@@ -3,8 +3,31 @@ import SwiftUI
 /// クイズ進捗を表示する再利用可能なビュー
 struct QuizProgressView: View {
   let progress: ProposalProgress
+  /// 一覧行など高さを抑えたい場所向けに、バー+進捗率+回答数を1行へ集約する
+  var compact: Bool = false
 
   var body: some View {
+    if compact {
+      HStack(spacing: AppSpacing.sm) {
+        ProgressView(value: progress.progressRate)
+          .tint(progressColor)
+
+        Text("\(Int(progress.progressPercentage))%")
+          .font(AppFont.caption)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+
+        Text("\(progress.answeredCount)/\(progress.totalCount)問")
+          .font(AppFont.caption2)
+          .foregroundStyle(.secondary)
+          .monospacedDigit()
+      }
+    } else {
+      detail
+    }
+  }
+
+  private var detail: some View {
     VStack(alignment: .leading, spacing: 4) {
       // プログレスインジケータと進捗率
       HStack(spacing: 8) {

--- a/ios/se-masked-quiz/ProposalFeature/RelatedProposalCard.swift
+++ b/ios/se-masked-quiz/ProposalFeature/RelatedProposalCard.swift
@@ -1,0 +1,66 @@
+//
+//  RelatedProposalCard.swift
+//  se-masked-quiz
+//
+//  クイズ画面上部の「先に読むと理解しやすい提案」を示すミニカード。
+//  極小チップだと視認性・タップ性が低かったため、ID+タイトル2行のカード型にする。
+//  スクロールコンテンツ内のためLiquid Glassは使わず不透明系の塗りにする。
+//
+
+import SwiftUI
+
+struct RelatedProposalCard: View {
+  let proposal: SwiftEvolution
+
+  /// Dynamic Typeに追従してカード幅も広げ、タイトル2行の可読性を保つ
+  @ScaledMetric(relativeTo: .caption) private var cardWidth: CGFloat = 180
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: AppSpacing.xs) {
+      Text(proposal.displayId)
+        .font(AppFont.caption.bold())
+        .foregroundStyle(SemanticColor.accent)
+      MarkdownText(proposal.title)
+        .font(AppFont.caption)
+        .foregroundStyle(.primary)
+        .lineLimit(2)
+        .multilineTextAlignment(.leading)
+    }
+    .padding(AppSpacing.sm)
+    .frame(width: cardWidth, alignment: .topLeading)
+    .frame(minHeight: 44)
+    .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: AppRadius.medium))
+    .contentShape(RoundedRectangle(cornerRadius: AppRadius.medium))
+    .accessibilityElement(children: .combine)
+  }
+}
+
+#Preview {
+  ScrollView(.horizontal) {
+    HStack(spacing: AppSpacing.sm) {
+      RelatedProposalCard(
+        proposal: SwiftEvolution(
+          id: "1",
+          proposalId: "0296",
+          title: "Async/await",
+          reviewManager: nil,
+          status: "**Implemented (Swift 5.5)**",
+          authors: "",
+          content: ""
+        )
+      )
+      RelatedProposalCard(
+        proposal: SwiftEvolution(
+          id: "2",
+          proposalId: "0306",
+          title: "Actors with a very long title that wraps to two lines",
+          reviewManager: nil,
+          status: "**Implemented (Swift 5.5)**",
+          authors: "",
+          content: ""
+        )
+      )
+    }
+    .padding()
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/StreakStatsScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/StreakStatsScreen.swift
@@ -8,9 +8,6 @@
 
 import SwiftUI
 
-/// ストリーク統計画面への遷移値。NavigationStack の value-based 遷移で使う。
-struct StreakStatsRoute: Hashable {}
-
 struct StreakStatsScreen: View {
   @Environment(\.streakRepository) private var streakRepository
   @Environment(\.quizRepository) private var quizRepository

--- a/ios/se-masked-quiz/Services/DeepLinkRouter.swift
+++ b/ios/se-masked-quiz/Services/DeepLinkRouter.swift
@@ -25,7 +25,7 @@ final class DeepLinkRouter {
   }
 
   /// DeepLink/通知に応じて切り替えるタブ
-  var selectedTrack: ProposalTrack = .swiftEvolution
+  var selectedTab: AppTab = .track(.swiftEvolution)
   /// 各 `ProposalListScreen` が自分の track と一致した時に消費する保留中のチャレンジ
   var pendingChallenge: PendingChallenge?
 
@@ -50,7 +50,7 @@ final class DeepLinkRouter {
   }
 
   private func applyChallenge(track: ProposalTrack, proposalId: String) {
-    selectedTrack = track
+    selectedTab = .track(track)
     pendingChallenge = PendingChallenge(track: track, proposalId: Self.normalize(proposalId))
   }
 

--- a/ios/se-masked-quiz/se_masked_quizApp.swift
+++ b/ios/se-masked-quiz/se_masked_quizApp.swift
@@ -28,17 +28,24 @@ struct se_masked_quizApp: App {
 
   var body: some Scene {
     WindowGroup {
-      TabView(selection: Bindable(router).selectedTrack) {
+      TabView(selection: Bindable(router).selectedTab) {
         ProposalListScreen(track: .swiftEvolution)
           .tabItem {
             Label("Swift Evolution", systemImage: "swift")
           }
-          .tag(ProposalTrack.swiftEvolution)
+          .tag(AppTab.track(.swiftEvolution))
         ProposalListScreen(track: .swiftTesting)
           .tabItem {
             Label("Swift Testing", systemImage: "checkmark.seal")
           }
-          .tag(ProposalTrack.swiftTesting)
+          .tag(AppTab.track(.swiftTesting))
+        NavigationStack {
+          StreakStatsScreen()
+        }
+        .tabItem {
+          Label("学習記録", systemImage: "chart.bar.fill")
+        }
+        .tag(AppTab.stats)
       }
       .environment(\.analytics, analytics)
       .environment(\.streakRepository, streakRepository)

--- a/ios/se-masked-quizTests/DeepLinkRouterTests.swift
+++ b/ios/se-masked-quizTests/DeepLinkRouterTests.swift
@@ -14,7 +14,7 @@ struct DeepLinkRouterTests {
     let sut = DeepLinkRouter()
     let url = URL(string: "semaskedquiz://challenge?track=swiftEvolution&proposalId=SE-0401")!
     sut.handle(url: url)
-    #expect(sut.selectedTrack == .swiftEvolution)
+    #expect(sut.selectedTab == .track(.swiftEvolution))
     #expect(
       sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
         track: .swiftEvolution, proposalId: "0401"))
@@ -25,7 +25,7 @@ struct DeepLinkRouterTests {
     let sut = DeepLinkRouter()
     let url = URL(string: "semaskedquiz://challenge?track=swiftTesting&proposalId=ST-0012")!
     sut.handle(url: url)
-    #expect(sut.selectedTrack == .swiftTesting)
+    #expect(sut.selectedTab == .track(.swiftTesting))
     #expect(
       sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
         track: .swiftTesting, proposalId: "0012"))
@@ -80,7 +80,7 @@ struct DeepLinkRouterTests {
       DeepLinkRouter.UserInfoKey.track: "swiftEvolution",
       DeepLinkRouter.UserInfoKey.proposalId: "SE-0401",
     ])
-    #expect(sut.selectedTrack == .swiftEvolution)
+    #expect(sut.selectedTab == .track(.swiftEvolution))
     #expect(
       sut.pendingChallenge == DeepLinkRouter.PendingChallenge(
         track: .swiftEvolution, proposalId: "0401"))

--- a/ios/se-masked-quizTests/DependencyGraphViewModelTests.swift
+++ b/ios/se-masked-quizTests/DependencyGraphViewModelTests.swift
@@ -86,4 +86,34 @@ struct DependencyGraphViewModelTests {
     #expect(abs(hypot(a.x, a.y) - 100) < 0.0001)
     #expect(abs(hypot(b.x, b.y) - 100) < 0.0001)
   }
+
+  /// maxNodes 上限近くまでノードが集まったリング（root + 39ノード）を作る。
+  private func crowdedNodes() -> [GraphNode] {
+    [GraphNode(id: "R", title: "r", hop: 0)]
+      + (1 ... 39).map { GraphNode(id: String(format: "%04d", $0), title: "n\($0)", hop: 1) }
+  }
+
+  @Test("RadialLayout: 混雑リングは半径が広がり、隣接ノードが重ならない距離を保つ")
+  func radialLayoutCrowded() throws {
+    let layout = RadialLayout.compute(nodes: crowdedNodes(), center: .zero, ringSpacing: 160)
+    #expect(layout.positions["R"] == .zero)
+
+    let first = try #require(layout.positions["0001"])
+    #expect(hypot(first.x, first.y) > 160)
+
+    let ids = (1 ... 39).map { String(format: "%04d", $0) }
+    for index in 0 ..< (ids.count - 1) {
+      let a = try #require(layout.positions[ids[index]])
+      let b = try #require(layout.positions[ids[index + 1]])
+      #expect(hypot(a.x - b.x, a.y - b.y) >= 60)
+    }
+  }
+
+  @Test("RadialLayout: 入力順に依存せず同一レイアウトになる（決定論）")
+  func radialLayoutDeterministic() {
+    let nodes = crowdedNodes()
+    let a = RadialLayout.compute(nodes: nodes, center: .zero, ringSpacing: 160)
+    let b = RadialLayout.compute(nodes: nodes.shuffled(), center: .zero, ringSpacing: 160)
+    #expect(a.positions == b.positions)
+  }
 }

--- a/ios/se-masked-quizTests/ProposalStatusTests.swift
+++ b/ios/se-masked-quizTests/ProposalStatusTests.swift
@@ -1,0 +1,132 @@
+import Testing
+
+@testable import se_masked_quiz
+
+@Suite("ProposalStatus Tests")
+struct ProposalStatusTests {
+
+  // MARK: - Implemented系
+
+  @Test("Implemented - バージョン付き")
+  func implementedWithVersion() {
+    let status = ProposalStatus.parse("**Implemented (Swift 5.9)**")
+    #expect(status == .implemented(version: "5.9"))
+    #expect(status.label == "Swift 5.9")
+  }
+
+  @Test("Implemented - パッチバージョン付き")
+  func implementedWithPatchVersion() {
+    let status = ProposalStatus.parse("**Implemented (Swift 3.0.1)**")
+    #expect(status == .implemented(version: "3.0.1"))
+    #expect(status.label == "Swift 3.0.1")
+  }
+
+  @Test("Implemented - バージョン無し")
+  func implementedWithoutVersion() {
+    let status = ProposalStatus.parse("**Implemented**")
+    #expect(status == .implemented(version: nil))
+    #expect(status.label == "Implemented")
+  }
+
+  @Test("Implemented with Modifications はimplemented扱い")
+  func implementedWithModifications() {
+    let status = ProposalStatus.parse("**Implemented with Modifications (Swift 5.4)**")
+    #expect(status == .implemented(version: "5.4"))
+  }
+
+  @Test("Partially implemented はimplementedより優先して判定される")
+  func partiallyImplemented() {
+    let status = ProposalStatus.parse("**Partially implemented (Swift 5.1)**")
+    #expect(status == .partiallyImplemented)
+    #expect(status.label == "Partially Implemented")
+  }
+
+  // MARK: - レビュー進行系
+
+  @Test("Accepted")
+  func accepted() {
+    #expect(ProposalStatus.parse("**Accepted**") == .accepted)
+  }
+
+  @Test("Accepted with modifications はaccepted扱い")
+  func acceptedWithModifications() {
+    #expect(ProposalStatus.parse("**Accepted with modifications**") == .accepted)
+  }
+
+  @Test("Active review - レビュー期間付き")
+  func activeReviewWithPeriod() {
+    #expect(
+      ProposalStatus.parse("**Active review (March 1...March 11, 2024)**") == .activeReview)
+  }
+
+  @Test("Active Review - 大文字ゆれ")
+  func activeReviewCaseVariant() {
+    #expect(ProposalStatus.parse("**Active Review**") == .activeReview)
+  }
+
+  @Test("Previewing")
+  func previewing() {
+    #expect(ProposalStatus.parse("**Previewing**") == .previewing)
+  }
+
+  // MARK: - 不成立系
+
+  @Test("Rejected")
+  func rejected() {
+    #expect(ProposalStatus.parse("**Rejected**") == .rejected)
+  }
+
+  @Test("Rejected - Rationaleリンク付きでもリンク文字列を含まない")
+  func rejectedWithRationaleLink() {
+    let status = ProposalStatus.parse(
+      "**Rejected** ([Rationale](https://forums.swift.org/t/rationale/12345))")
+    #expect(status == .rejected)
+    #expect(status.label == "Rejected")
+  }
+
+  @Test("Returned for revision")
+  func returnedForRevision() {
+    #expect(ProposalStatus.parse("**Returned for revision**") == .returned)
+  }
+
+  @Test("Returned for Revision - 大文字ゆれ")
+  func returnedCaseVariant() {
+    #expect(ProposalStatus.parse("**Returned for Revision**") == .returned)
+  }
+
+  @Test("Withdrawn")
+  func withdrawn() {
+    #expect(ProposalStatus.parse("**Withdrawn**") == .withdrawn)
+  }
+
+  @Test("Expired はwithdrawn扱い")
+  func expired() {
+    #expect(ProposalStatus.parse("**Expired**") == .withdrawn)
+  }
+
+  // MARK: - エッジケース
+
+  @Test("前後の空白ゆれを許容する")
+  func whitespaceVariant() {
+    #expect(ProposalStatus.parse("  **Implemented (Swift 5.9)**  ") == .implemented(version: "5.9"))
+  }
+
+  @Test("nil はunknown（空ラベル）")
+  func nilStatus() {
+    let status = ProposalStatus.parse(nil)
+    #expect(status == .unknown(text: ""))
+    #expect(status.label.isEmpty)
+  }
+
+  @Test("空文字はunknown（空ラベル）")
+  func emptyStatus() {
+    #expect(ProposalStatus.parse("").label.isEmpty)
+  }
+
+  @Test("未知の語彙はunknownとして本文をそのままラベルにする")
+  func unknownVocabulary() {
+    let status = ProposalStatus.parse("**Scheduled for review (April 2026)**")
+    #expect(status == .unknown(text: "Scheduled for review"))
+    #expect(status.label == "Scheduled for review")
+  }
+}


### PR DESCRIPTION
## 概要

iPhone 15 Pro実機でのデザインフィードバック（余白過多で情報密度が低い・前提提案チップと依存グラフの視認性が低い・44pt未満のタップターゲット）に対応し、主要3画面を再設計しました。あわせて、SEタブのチャレンジセルに従属していたストリーク統計を独立した「学習記録」タブへ昇格しました。

## 変更内容

### 1. 提案一覧の情報密度改善
- 行を新コンポーネント`ProposalRowView`に再設計：IDバッジ + 色付きステータスバッジ + タイトル2行 + 1行進捗
- statusのMarkdown文字列をパースする`ProposalStatus`を新設。Implemented=緑（Swiftバージョン表示）/ Accepted=青 / Active Review=橙 / Rejected=赤 等に色分け
- authors/reviewManagerの生Markdown 2行を行から削除（提案本文に記載があるため情報は失われない）
- `FavoritesScreen`の重複行実装も同一コンポーネントへ統一

### 2. 「先に読むと理解しやすい提案」のカード化
- 極小チップ（9pt級フォント）を`RelatedProposalCard`（幅180pt・ID accent色bold・タイトル2行・高さ44pt以上）へ変更
- 「#401」と桁落ちしていた表記を「SE-0401」へ修正

### 3. 依存グラフの可読性改善
- エッジに参照方向を示す矢印を追加し、選択ノードの接続エッジをaccent色で強調
- ノードタイトルを9pt固定→caption2の2行表示に拡大。root=accent塗り+白文字、非rootは不透明背景でエッジの透けを防止
- ノードが多いリングは半径を自動拡張し内外交互配置で重なりを回避（既存の`radialLayout`テストは無変更でグリーン）
- 凡例と表示リセットボタンを追加

### 4. 「学習記録」タブの新設
- `AppTab`（`.track(ProposalTrack)` / `.stats`）を導入しTabViewを3タブ化
- 統計はSE+ST横断データ（正答率は両トラック集計）なのに、入口がSEタブのセル横アイコンのみでSTタブから到達不能だった問題を解消
- チャレンジセル横の統計ボタンと`StreakStatsRoute`を削除

## テスト

- 全ユニットテスト成功（新規: `ProposalStatusTests` 19件 / `RadialLayout`混雑時・決定論テスト2件 / `DeepLinkRouterTests`をAppTab対応に更新）
- iOSシミュレータ + macOSビルド成功
- `swift-complexity ios/se-masked-quiz --recursive --threshold 10` パス
- シミュレータ（iPhone 17 Pro）で一覧画面の表示を目視確認済み

## レビューポイント

- `ProposalStatus.parse`の判定順序（"Partially implemented"が"implemented"を包含する等、順序に意味があります）
- `RadialLayout`の混雑時補正のガード条件（非混雑時は従来配置を完全維持）
- DeepLink経由のタブ選択が`selectedTab = .track(track)`へ正しく置き換わっていること

<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

https://claude.ai/code/session_019ipSEEbn4VAJwJNtsNDvc4