### PR TITLE
機能追加: プロポーザル一覧にステータス絞り込みを追加

### DIFF
--- a/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
+++ b/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
@@ -2,8 +2,7 @@
 //  ProposalStatusFilter.swift
 //  se-masked-quiz
 //
-//  一覧画面のステータス絞り込み条件。Payload REST の where クエリへ写像する。
-//  キーワードは ProposalStatus.parse の判定基準と対応を保つこと。
+//  一覧のステータス絞り込み条件。
 //
 
 import Foundation
@@ -19,8 +18,7 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
   case rejected
   case withdrawn
 
-  /// メニュー表示用ラベル。一覧バッジ（ProposalStatus.label）の表記と揃える。
-  /// switch にすると case 数で循環的複雑度が閾値(10)を超えるため辞書で引く
+  /// 1つのswitchに全caseを並べると循環的複雑度が閾値(10)を超えるため辞書で引く
   var label: String {
     Self.labels[self] ?? ""
   }
@@ -37,8 +35,6 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
     .withdrawn: "Withdrawn",
   ]
 
-  /// Payload REST の where[and][N]... に載せる条件を組み立てる。
-  /// status はMarkdown混じりの自由文字列のため contains ベースで照合する。
   func queryItems(startingAndIndex: Int) -> [URLQueryItem] {
     switch self {
     case .all:
@@ -52,7 +48,6 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
           name: "where[and][\(startingAndIndex + 1)][status][not_like]", value: "partially"),
       ]
     case .withdrawn:
-      // ProposalStatus.parse と同様に "expired" も Withdrawn として扱う
       return [
         URLQueryItem(
           name: "where[and][\(startingAndIndex)][or][0][status][contains]", value: "withdrawn"),
@@ -67,7 +62,6 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
     }
   }
 
-  /// 単一 contains で照合できる case のキーワード
   private var containsKeyword: String {
     switch self {
     case .partiallyImplemented: return "partially"

--- a/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
+++ b/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
@@ -18,7 +18,6 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
   case rejected
   case withdrawn
 
-  /// 1つのswitchに全caseを並べると循環的複雑度が閾値(10)を超えるため辞書で引く
   var label: String {
     Self.labels[self] ?? ""
   }
@@ -40,7 +39,6 @@ enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
     case .all:
       return []
     case .implemented:
-      // "Partially implemented" も "implemented" を含むため not_like で除外する
       return [
         URLQueryItem(
           name: "where[and][\(startingAndIndex)][status][contains]", value: "implemented"),

--- a/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
+++ b/ios/se-masked-quiz/Models/ProposalStatusFilter.swift
@@ -1,0 +1,82 @@
+//
+//  ProposalStatusFilter.swift
+//  se-masked-quiz
+//
+//  一覧画面のステータス絞り込み条件。Payload REST の where クエリへ写像する。
+//  キーワードは ProposalStatus.parse の判定基準と対応を保つこと。
+//
+
+import Foundation
+
+enum ProposalStatusFilter: String, CaseIterable, Sendable, Hashable {
+  case all
+  case implemented
+  case partiallyImplemented
+  case accepted
+  case activeReview
+  case previewing
+  case returned
+  case rejected
+  case withdrawn
+
+  /// メニュー表示用ラベル。一覧バッジ（ProposalStatus.label）の表記と揃える。
+  /// switch にすると case 数で循環的複雑度が閾値(10)を超えるため辞書で引く
+  var label: String {
+    Self.labels[self] ?? ""
+  }
+
+  private static let labels: [ProposalStatusFilter: String] = [
+    .all: "すべて",
+    .implemented: "Implemented",
+    .partiallyImplemented: "Partially Implemented",
+    .accepted: "Accepted",
+    .activeReview: "Active Review",
+    .previewing: "Previewing",
+    .returned: "Returned",
+    .rejected: "Rejected",
+    .withdrawn: "Withdrawn",
+  ]
+
+  /// Payload REST の where[and][N]... に載せる条件を組み立てる。
+  /// status はMarkdown混じりの自由文字列のため contains ベースで照合する。
+  func queryItems(startingAndIndex: Int) -> [URLQueryItem] {
+    switch self {
+    case .all:
+      return []
+    case .implemented:
+      // "Partially implemented" も "implemented" を含むため not_like で除外する
+      return [
+        URLQueryItem(
+          name: "where[and][\(startingAndIndex)][status][contains]", value: "implemented"),
+        URLQueryItem(
+          name: "where[and][\(startingAndIndex + 1)][status][not_like]", value: "partially"),
+      ]
+    case .withdrawn:
+      // ProposalStatus.parse と同様に "expired" も Withdrawn として扱う
+      return [
+        URLQueryItem(
+          name: "where[and][\(startingAndIndex)][or][0][status][contains]", value: "withdrawn"),
+        URLQueryItem(
+          name: "where[and][\(startingAndIndex)][or][1][status][contains]", value: "expired"),
+      ]
+    default:
+      return [
+        URLQueryItem(
+          name: "where[and][\(startingAndIndex)][status][contains]", value: containsKeyword)
+      ]
+    }
+  }
+
+  /// 単一 contains で照合できる case のキーワード
+  private var containsKeyword: String {
+    switch self {
+    case .partiallyImplemented: return "partially"
+    case .accepted: return "accepted"
+    case .activeReview: return "active review"
+    case .previewing: return "previewing"
+    case .returned: return "returned"
+    case .rejected: return "rejected"
+    default: return ""
+    }
+  }
+}

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -344,7 +344,6 @@ struct ProposalListScreen: View {
   ) {
     currentPage = 1
     hasNextPage = true
-    // 下端までスクロールした状態で絞り込むと true のままになり、次ページを読む遷移が起きなくなる
     shouldLoadNextPage = false
     proposals = .loading([])
     Task {

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -28,6 +28,7 @@ struct ProposalListScreen: View {
   @State private var searchText: String = ""
   @State private var debouncedSearchText: String = ""
   @State private var sortOrder: ProposalSortOrder = .descending
+  @State private var statusFilter: ProposalStatusFilter = .all
   @State private var navigationPath = NavigationPath()
 
   /// このタブのトラック（Swift Evolution / Swift Testing）。
@@ -62,10 +63,15 @@ struct ProposalListScreen: View {
         await debounceSearchText()
       }
       .onChange(of: debouncedSearchText) { _, newValue in
-        reloadFromFirstPage(searchText: newValue, sortOrder: sortOrder)
+        reloadFromFirstPage(searchText: newValue, sortOrder: sortOrder, statusFilter: statusFilter)
       }
       .onChange(of: sortOrder) { _, newValue in
-        reloadFromFirstPage(searchText: debouncedSearchText, sortOrder: newValue)
+        reloadFromFirstPage(
+          searchText: debouncedSearchText, sortOrder: newValue, statusFilter: statusFilter)
+      }
+      .onChange(of: statusFilter) { _, newValue in
+        reloadFromFirstPage(
+          searchText: debouncedSearchText, sortOrder: sortOrder, statusFilter: newValue)
       }
       .task {
         await loadInitialProposalsIfNeeded()
@@ -115,6 +121,7 @@ struct ProposalListScreen: View {
         page: currentPage,
         searchText: debouncedSearchText.isEmpty ? nil : debouncedSearchText,
         sortOrder: sortOrder,
+        statusFilter: statusFilter,
         track: track
       )
       hasNextPage = response.hasNextPage
@@ -131,7 +138,8 @@ struct ProposalListScreen: View {
     guard proposals.content.isEmpty, !proposals.isLoading else { return }
     do {
       proposals.startLoading()
-      let response = try await repository.fetch(page: currentPage, sortOrder: sortOrder, track: track)
+      let response = try await repository.fetch(
+        page: currentPage, sortOrder: sortOrder, statusFilter: statusFilter, track: track)
       hasNextPage = response.hasNextPage
       self.proposals = .loaded(response.docs.map { $0.toSwiftEvolution(track: track) })
       currentPage += 1
@@ -228,11 +236,16 @@ struct ProposalListScreen: View {
       }
     }
     .overlay {
-      if proposals.content.isEmpty,
-        !proposals.isLoading,
-        !debouncedSearchText.isEmpty
-      {
-        ContentUnavailableView.search(text: debouncedSearchText)
+      if proposals.content.isEmpty, !proposals.isLoading {
+        if !debouncedSearchText.isEmpty {
+          ContentUnavailableView.search(text: debouncedSearchText)
+        } else if statusFilter != .all {
+          ContentUnavailableView(
+            "該当する提案がありません",
+            systemImage: "line.3.horizontal.decrease.circle",
+            description: Text("ステータス「\(statusFilter.label)」の提案は見つかりませんでした")
+          )
+        }
       }
     }
     .navigationTitle(track.title)
@@ -269,7 +282,8 @@ struct ProposalListScreen: View {
           }
           .accessibilityLabel("お気に入り")
         }
-        ToolbarItem(placement: .topBarTrailing) {
+        ToolbarItemGroup(placement: .topBarTrailing) {
+          statusFilterMenu
           sortMenu
         }
       #elseif os(macOS)
@@ -286,10 +300,28 @@ struct ProposalListScreen: View {
           }
           .accessibilityLabel("お気に入り")
         }
-        ToolbarItem(placement: .primaryAction) {
+        ToolbarItemGroup(placement: .primaryAction) {
+          statusFilterMenu
           sortMenu
         }
       #endif
+    }
+  }
+
+  private var statusFilterMenu: some View {
+    Menu {
+      Picker("ステータス", selection: $statusFilter) {
+        ForEach(ProposalStatusFilter.allCases, id: \.self) { filter in
+          Text(filter.label).tag(filter)
+        }
+      }
+    } label: {
+      Image(
+        systemName: statusFilter == .all
+          ? "line.3.horizontal.decrease.circle"
+          : "line.3.horizontal.decrease.circle.fill"
+      )
+      .accessibilityLabel("ステータスで絞り込み")
     }
   }
 
@@ -307,7 +339,9 @@ struct ProposalListScreen: View {
 
   // MARK: - Private Methods
 
-  private func reloadFromFirstPage(searchText: String, sortOrder: ProposalSortOrder) {
+  private func reloadFromFirstPage(
+    searchText: String, sortOrder: ProposalSortOrder, statusFilter: ProposalStatusFilter
+  ) {
     currentPage = 1
     hasNextPage = true
     proposals = .loading([])
@@ -317,6 +351,7 @@ struct ProposalListScreen: View {
           page: currentPage,
           searchText: searchText.isEmpty ? nil : searchText,
           sortOrder: sortOrder,
+          statusFilter: statusFilter,
           track: track
         )
         hasNextPage = response.hasNextPage

--- a/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift
@@ -344,6 +344,8 @@ struct ProposalListScreen: View {
   ) {
     currentPage = 1
     hasNextPage = true
+    // 下端までスクロールした状態で絞り込むと true のままになり、次ページを読む遷移が起きなくなる
+    shouldLoadNextPage = false
     proposals = .loading([])
     Task {
       do {

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -167,7 +167,6 @@ struct SERepository: Sendable {
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "sort", value: sortOrder.queryValue),
     ]
-    // 検索とステータス絞り込みをANDで両立させるため、条件は where[and][N] 配下に並べる
     var andIndex = 0
     let trimmedSearch = (searchText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     if !trimmedSearch.isEmpty {

--- a/ios/se-masked-quiz/Repositories/SERepository.swift
+++ b/ios/se-masked-quiz/Repositories/SERepository.swift
@@ -49,6 +49,7 @@ struct SERepository: Sendable {
     page: Int,
     searchText: String? = nil,
     sortOrder: ProposalSortOrder = .descending,
+    statusFilter: ProposalStatusFilter = .all,
     track: ProposalTrack = .swiftEvolution
   ) async throws -> PayloadListResponse<PayloadProposal> {
     let baseURL = Env.serverBaseURL
@@ -59,6 +60,7 @@ struct SERepository: Sendable {
       limit: Self.pageSize,
       searchText: searchText,
       sortOrder: sortOrder,
+      statusFilter: statusFilter,
       track: track
     )
     var request = URLRequest(url: requestURL)
@@ -150,6 +152,7 @@ struct SERepository: Sendable {
     limit: Int,
     searchText: String? = nil,
     sortOrder: ProposalSortOrder = .descending,
+    statusFilter: ProposalStatusFilter = .all,
     track: ProposalTrack = .swiftEvolution
   ) throws -> URL {
     var trimmed = baseURL.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -164,12 +167,19 @@ struct SERepository: Sendable {
       URLQueryItem(name: "limit", value: String(limit)),
       URLQueryItem(name: "sort", value: sortOrder.queryValue),
     ]
+    // 検索とステータス絞り込みをANDで両立させるため、条件は where[and][N] 配下に並べる
+    var andIndex = 0
     let trimmedSearch = (searchText ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
     if !trimmedSearch.isEmpty {
-      items.append(URLQueryItem(name: "where[or][0][title][contains]", value: trimmedSearch))
-      items.append(URLQueryItem(name: "where[or][1][proposalId][contains]", value: trimmedSearch))
-      items.append(URLQueryItem(name: "where[or][2][authors][contains]", value: trimmedSearch))
+      for (fieldIndex, field) in ["title", "proposalId", "authors"].enumerated() {
+        items.append(
+          URLQueryItem(
+            name: "where[and][\(andIndex)][or][\(fieldIndex)][\(field)][contains]",
+            value: trimmedSearch))
+      }
+      andIndex += 1
     }
+    items.append(contentsOf: statusFilter.queryItems(startingAndIndex: andIndex))
     components.queryItems = items
     guard let url = components.url else {
       throw SERepositoryError.invalidBaseURL

--- a/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
+++ b/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
@@ -2,18 +2,18 @@ import Foundation
 import Testing
 @testable import se_masked_quiz
 
-@Suite("ProposalStatusFilter")
+@Suite("提案のステータス絞り込み")
 struct ProposalStatusFilterTests {
 
-  @Test("全caseがメニュー表示用ラベルを持つ")
+  @Test("絞り込みメニューのすべての項目に表示名がある")
   func allCasesHaveLabels() {
     for filter in ProposalStatusFilter.allCases {
-      #expect(!filter.label.isEmpty, "\(filter) のラベルが空")
+      #expect(!filter.label.isEmpty, "\(filter) の表示名が空です")
     }
   }
 
   @Test(
-    "単一containsのcaseは status[contains] クエリを1つ生成する",
+    "ステータスを選ぶと、その語を含む提案だけを要求する",
     arguments: [
       (ProposalStatusFilter.partiallyImplemented, "partially"),
       (.accepted, "accepted"),
@@ -27,12 +27,12 @@ struct ProposalStatusFilterTests {
     #expect(items == [URLQueryItem(name: "where[and][0][status][contains]", value: keyword)])
   }
 
-  @Test("all はクエリを生成しない")
+  @Test("「すべて」を選んだときは絞り込まない")
   func allProducesNoQuery() {
     #expect(ProposalStatusFilter.all.queryItems(startingAndIndex: 0).isEmpty)
   }
 
-  @Test("startingAndIndex が条件のインデックスに反映される")
+  @Test("キーワード検索と併用しても、絞り込み条件が別枠で追加される")
   func startingAndIndexIsApplied() {
     let items = ProposalStatusFilter.implemented.queryItems(startingAndIndex: 1)
     #expect(
@@ -43,7 +43,7 @@ struct ProposalStatusFilterTests {
   }
 
   @Test(
-    "キーワードは ProposalStatus.parse の判定と整合する",
+    "一覧に表示されるステータスと、絞り込みの分類が一致する",
     arguments: [
       ("**Implemented (Swift 5.9)**", ProposalStatusFilter.implemented),
       ("**Partially implemented (Swift 6.0)**", .partiallyImplemented),
@@ -57,15 +57,14 @@ struct ProposalStatusFilterTests {
     ])
   func keywordsMatchParseResult(raw: String, filter: ProposalStatusFilter) {
     let parsed = ProposalStatus.parse(raw)
-    let matched = ProposalStatusFilterTests.matches(raw: raw, filter: filter)
-    #expect(matched, "\(filter) のクエリ条件が \(raw) にマッチしない")
+    let matched = ProposalStatusFilterTests.simulatedServerMatch(raw: raw, filter: filter)
+    #expect(matched, "「\(raw)」が「\(filter.label)」の絞り込みで取得できません")
     #expect(
       ProposalStatusFilterTests.expectedFilter(for: parsed) == filter,
-      "parse結果 \(parsed) とフィルタ \(filter) が対応しない")
+      "一覧では「\(parsed.label)」と表示されるのに、絞り込みは「\(filter.label)」に分類しています")
   }
 
-  /// サーバーの contains/not_like (case-insensitive LIKE) を模して照合する
-  private static func matches(raw: String, filter: ProposalStatusFilter) -> Bool {
+  private static func simulatedServerMatch(raw: String, filter: ProposalStatusFilter) -> Bool {
     let lowered = raw.lowercased()
     let items = filter.queryItems(startingAndIndex: 0)
     for item in items where item.name.contains("[or]") {

--- a/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
+++ b/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import Testing
+@testable import se_masked_quiz
+
+@Suite("ProposalStatusFilter")
+struct ProposalStatusFilterTests {
+
+  @Test("全caseがメニュー表示用ラベルを持つ")
+  func allCasesHaveLabels() {
+    for filter in ProposalStatusFilter.allCases {
+      #expect(!filter.label.isEmpty, "\(filter) のラベルが空")
+    }
+  }
+
+  @Test(
+    "単一containsのcaseは status[contains] クエリを1つ生成する",
+    arguments: [
+      (ProposalStatusFilter.partiallyImplemented, "partially"),
+      (.accepted, "accepted"),
+      (.activeReview, "active review"),
+      (.previewing, "previewing"),
+      (.returned, "returned"),
+      (.rejected, "rejected"),
+    ])
+  func singleContainsQuery(filter: ProposalStatusFilter, keyword: String) {
+    let items = filter.queryItems(startingAndIndex: 0)
+    #expect(items == [URLQueryItem(name: "where[and][0][status][contains]", value: keyword)])
+  }
+
+  @Test("all はクエリを生成しない")
+  func allProducesNoQuery() {
+    #expect(ProposalStatusFilter.all.queryItems(startingAndIndex: 0).isEmpty)
+  }
+
+  @Test("startingAndIndex が条件のインデックスに反映される")
+  func startingAndIndexIsApplied() {
+    let items = ProposalStatusFilter.implemented.queryItems(startingAndIndex: 1)
+    #expect(
+      items == [
+        URLQueryItem(name: "where[and][1][status][contains]", value: "implemented"),
+        URLQueryItem(name: "where[and][2][status][not_like]", value: "partially"),
+      ])
+  }
+
+  /// フィルタのキーワードが ProposalStatus.parse の判定結果と食い違っていないことを確認する
+  @Test(
+    "キーワードは ProposalStatus.parse の判定と整合する",
+    arguments: [
+      ("**Implemented (Swift 5.9)**", ProposalStatusFilter.implemented),
+      ("**Partially implemented (Swift 6.0)**", .partiallyImplemented),
+      ("**Accepted**", .accepted),
+      ("**Active review (March 1...11, 2024)**", .activeReview),
+      ("**Previewing**", .previewing),
+      ("**Returned for revision**", .returned),
+      ("**Rejected**", .rejected),
+      ("**Withdrawn**", .withdrawn),
+      ("**Expired**", .withdrawn),
+    ])
+  func keywordsMatchParseResult(raw: String, filter: ProposalStatusFilter) {
+    let parsed = ProposalStatus.parse(raw)
+    let matched = ProposalStatusFilterTests.matches(raw: raw, filter: filter)
+    #expect(matched, "\(filter) のクエリ条件が \(raw) にマッチしない")
+    #expect(
+      ProposalStatusFilterTests.expectedFilter(for: parsed) == filter,
+      "parse結果 \(parsed) とフィルタ \(filter) が対応しない")
+  }
+
+  /// サーバーの contains/not_like (case-insensitive LIKE) を模して照合する
+  private static func matches(raw: String, filter: ProposalStatusFilter) -> Bool {
+    let lowered = raw.lowercased()
+    let items = filter.queryItems(startingAndIndex: 0)
+    for item in items where item.name.contains("[or]") {
+      // OR グループはいずれか1つの一致でよい
+      if lowered.contains(item.value ?? "") { return true }
+    }
+    let andItems = items.filter { !$0.name.contains("[or]") }
+    guard !andItems.isEmpty else { return false }
+    return andItems.allSatisfy { item in
+      let keyword = (item.value ?? "").lowercased()
+      return item.name.hasSuffix("[not_like]")
+        ? !lowered.contains(keyword)
+        : lowered.contains(keyword)
+    }
+  }
+
+  private static func expectedFilter(for status: ProposalStatus) -> ProposalStatusFilter? {
+    let mapping: [(ProposalStatus, ProposalStatusFilter)] = [
+      (.partiallyImplemented, .partiallyImplemented),
+      (.accepted, .accepted),
+      (.activeReview, .activeReview),
+      (.previewing, .previewing),
+      (.returned, .returned),
+      (.rejected, .rejected),
+      (.withdrawn, .withdrawn),
+    ]
+    if case .implemented = status { return .implemented }
+    return mapping.first { $0.0 == status }?.1
+  }
+}

--- a/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
+++ b/ios/se-masked-quizTests/ProposalStatusFilterTests.swift
@@ -42,7 +42,6 @@ struct ProposalStatusFilterTests {
       ])
   }
 
-  /// フィルタのキーワードが ProposalStatus.parse の判定結果と食い違っていないことを確認する
   @Test(
     "キーワードは ProposalStatus.parse の判定と整合する",
     arguments: [
@@ -70,7 +69,6 @@ struct ProposalStatusFilterTests {
     let lowered = raw.lowercased()
     let items = filter.queryItems(startingAndIndex: 0)
     for item in items where item.name.contains("[or]") {
-      // OR グループはいずれか1つの一致でよい
       if lowered.contains(item.value ?? "") { return true }
     }
     let andItems = items.filter { !$0.name.contains("[or]") }

--- a/ios/se-masked-quizTests/SERepositoryTests.swift
+++ b/ios/se-masked-quizTests/SERepositoryTests.swift
@@ -2,10 +2,10 @@ import Foundation
 import Testing
 @testable import se_masked_quiz
 
-@Suite("SERepository / Payload CMS REST API")
+@Suite("提案一覧の取得")
 struct SERepositoryTests {
 
-  @Test("Payload REST API レスポンスを正しくデコードできる")
+  @Test("サーバーの応答から提案を読み取れる")
   func decodePayloadListResponse() throws {
     let json = """
     {
@@ -41,7 +41,7 @@ struct SERepositoryTests {
     #expect(first.status == nil)
   }
 
-  @Test("PayloadProposal を SwiftEvolution に変換できる")
+  @Test("読み取った提案の各項目がアプリで扱う形に引き継がれる")
   func convertToSwiftEvolution() throws {
     let json = """
     {
@@ -76,7 +76,7 @@ struct SERepositoryTests {
     #expect(se.status == "Accepted")
   }
 
-  @Test("searchText未指定時は where 系クエリを含まず、デフォルトで降順ソートになる")
+  @Test("検索も絞り込みもしないときは、提案番号の新しい順で取得する")
   func proposalsURLWithoutSearchText() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com/",
@@ -90,7 +90,7 @@ struct SERepositoryTests {
     #expect(!query.contains("where"))
   }
 
-  @Test("sortOrder=ascending のとき sort=proposalId が指定される")
+  @Test("提案番号の古い順に並べ替えられる")
   func proposalsURLAscendingSort() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -102,7 +102,7 @@ struct SERepositoryTests {
     #expect(items.contains(URLQueryItem(name: "sort", value: "proposalId")))
   }
 
-  @Test("sortOrder=descending のとき sort=-proposalId が指定される")
+  @Test("提案番号の新しい順に並べ替えられる")
   func proposalsURLDescendingSort() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -114,7 +114,7 @@ struct SERepositoryTests {
     #expect(items.contains(URLQueryItem(name: "sort", value: "-proposalId")))
   }
 
-  @Test("searchText指定時は title/proposalId/authors への contains クエリが含まれる")
+  @Test("キーワード検索はタイトル・提案番号・著者のいずれかに一致する提案を探す")
   func proposalsURLWithSearchText() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -133,7 +133,7 @@ struct SERepositoryTests {
       items.contains(URLQueryItem(name: "where[and][0][or][2][authors][contains]", value: "actor")))
   }
 
-  @Test("statusFilter指定時は where[and][0][status][contains] が含まれる")
+  @Test("ステータスを選ぶと、そのステータスの提案だけを取得する")
   func proposalsURLWithStatusFilter() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -145,7 +145,7 @@ struct SERepositoryTests {
     #expect(items.contains(URLQueryItem(name: "where[and][0][status][contains]", value: "accepted")))
   }
 
-  @Test("statusFilter=implemented は partially を not_like で除外する")
+  @Test("Implemented で絞り込むと、Partially Implemented の提案は除外される")
   func proposalsURLWithImplementedFilter() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -160,7 +160,7 @@ struct SERepositoryTests {
       items.contains(URLQueryItem(name: "where[and][1][status][not_like]", value: "partially")))
   }
 
-  @Test("statusFilter=withdrawn は withdrawn/expired の OR 条件になる")
+  @Test("Withdrawn で絞り込むと、Expired の提案も含める")
   func proposalsURLWithWithdrawnFilter() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -177,7 +177,7 @@ struct SERepositoryTests {
         URLQueryItem(name: "where[and][0][or][1][status][contains]", value: "expired")))
   }
 
-  @Test("searchText と statusFilter の併用時は検索が and[0]、ステータスが and[1] に入る")
+  @Test("キーワード検索とステータス絞り込みを同時に使うと、両方の条件を満たす提案だけを取得する")
   func proposalsURLWithSearchTextAndStatusFilter() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -192,7 +192,7 @@ struct SERepositoryTests {
     #expect(items.contains(URLQueryItem(name: "where[and][1][status][contains]", value: "rejected")))
   }
 
-  @Test("statusFilter=all は where 系クエリを追加しない")
+  @Test("「すべて」を選んだときはステータスで絞り込まない")
   func proposalsURLWithAllStatusFilter() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -204,7 +204,7 @@ struct SERepositoryTests {
     #expect(!query.contains("where"))
   }
 
-  @Test("searchText が空白のみの場合は where 系クエリを含まない")
+  @Test("空白だけを入力しても検索条件として扱わない")
   func proposalsURLWithWhitespaceSearchText() throws {
     let url = try SERepository.proposalsURL(
       baseURL: "https://example.com",
@@ -216,7 +216,7 @@ struct SERepositoryTests {
     #expect(!query.contains("where"))
   }
 
-  @Test("proposalsByIdsURL は where[proposalId][in] とカンマ区切りIDを含む")
+  @Test("提案番号を複数指定して、まとめて取得できる")
   func proposalsByIdsURL() throws {
     let url = try SERepository.proposalsByIdsURL(
       baseURL: "https://example.com/",
@@ -227,7 +227,7 @@ struct SERepositoryTests {
     #expect(items.contains(URLQueryItem(name: "limit", value: "2")))
   }
 
-  @Test("graphNodesURL は in と select[proposalId]/select[title] を含み content を要求しない")
+  @Test("依存グラフ用の取得では、本文を除いた提案番号とタイトルだけを要求する")
   func graphNodesURL() throws {
     let url = try SERepository.graphNodesURL(
       baseURL: "https://example.com",
@@ -241,7 +241,7 @@ struct SERepositoryTests {
     #expect(!query.contains("select%5Bcontent%5D"))
   }
 
-  @Test("PayloadProposalNode を select レスポンスからデコードできる（content 不要）")
+  @Test("本文を含まない応答からでも、依存グラフ用の提案を読み取れる")
   func decodeGraphNode() throws {
     let json = """
     {
@@ -257,7 +257,7 @@ struct SERepositoryTests {
     #expect(first.title == "Structured Concurrency")
   }
 
-  @Test("PayloadHTTP.chunked は指定サイズで分割する")
+  @Test("まとめて取得する提案番号は、指定した件数ごとに分割される")
   func chunked() {
     let ids = (1 ... 5).map { String($0) }
     let chunks = PayloadHTTP.chunked(ids, size: 2)
@@ -267,7 +267,7 @@ struct SERepositoryTests {
     #expect(PayloadHTTP.chunked([], size: 2).isEmpty)
   }
 
-  @Test("ページネーション情報を正しくデコードできる")
+  @Test("次のページがあるかどうかを応答から読み取れる")
   func decodePagination() throws {
     let json = """
     {

--- a/ios/se-masked-quizTests/SERepositoryTests.swift
+++ b/ios/se-masked-quizTests/SERepositoryTests.swift
@@ -124,9 +124,84 @@ struct SERepositoryTests {
     )
     let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
     #expect(items.contains(URLQueryItem(name: "page", value: "2")))
-    #expect(items.contains(URLQueryItem(name: "where[or][0][title][contains]", value: "actor")))
-    #expect(items.contains(URLQueryItem(name: "where[or][1][proposalId][contains]", value: "actor")))
-    #expect(items.contains(URLQueryItem(name: "where[or][2][authors][contains]", value: "actor")))
+    #expect(
+      items.contains(URLQueryItem(name: "where[and][0][or][0][title][contains]", value: "actor")))
+    #expect(
+      items.contains(
+        URLQueryItem(name: "where[and][0][or][1][proposalId][contains]", value: "actor")))
+    #expect(
+      items.contains(URLQueryItem(name: "where[and][0][or][2][authors][contains]", value: "actor")))
+  }
+
+  @Test("statusFilter指定時は where[and][0][status][contains] が含まれる")
+  func proposalsURLWithStatusFilter() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      statusFilter: .accepted
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(items.contains(URLQueryItem(name: "where[and][0][status][contains]", value: "accepted")))
+  }
+
+  @Test("statusFilter=implemented は partially を not_like で除外する")
+  func proposalsURLWithImplementedFilter() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      statusFilter: .implemented
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(
+      items.contains(URLQueryItem(name: "where[and][0][status][contains]", value: "implemented")))
+    #expect(
+      items.contains(URLQueryItem(name: "where[and][1][status][not_like]", value: "partially")))
+  }
+
+  @Test("statusFilter=withdrawn は withdrawn/expired の OR 条件になる")
+  func proposalsURLWithWithdrawnFilter() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      statusFilter: .withdrawn
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(
+      items.contains(
+        URLQueryItem(name: "where[and][0][or][0][status][contains]", value: "withdrawn")))
+    #expect(
+      items.contains(
+        URLQueryItem(name: "where[and][0][or][1][status][contains]", value: "expired")))
+  }
+
+  @Test("searchText と statusFilter の併用時は検索が and[0]、ステータスが and[1] に入る")
+  func proposalsURLWithSearchTextAndStatusFilter() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      searchText: "actor",
+      statusFilter: .rejected
+    )
+    let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems ?? []
+    #expect(
+      items.contains(URLQueryItem(name: "where[and][0][or][0][title][contains]", value: "actor")))
+    #expect(items.contains(URLQueryItem(name: "where[and][1][status][contains]", value: "rejected")))
+  }
+
+  @Test("statusFilter=all は where 系クエリを追加しない")
+  func proposalsURLWithAllStatusFilter() throws {
+    let url = try SERepository.proposalsURL(
+      baseURL: "https://example.com",
+      page: 1,
+      limit: 10,
+      statusFilter: .all
+    )
+    let query = url.query ?? ""
+    #expect(!query.contains("where"))
   }
 
   @Test("searchText が空白のみの場合は where 系クエリを含まない")


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## 概要

提案一覧をステータスで絞り込めるようにした。「Implemented だけ見たい」「Active review 中の提案を追いたい」という読み分けを、一覧をスクロールせずに実現する。

一覧は10件ずつのサーバー側ページネーションで取得している。そのため取得済みの範囲だけをクライアントで絞ると、絞り込み結果が「読み込み済みのページ内の該当分」に限られてしまう。Payload REST の `where` クエリによるサーバー側フィルタとして実装した。

## 主な変更点

### `ProposalStatusFilter` を新設（`ios/se-masked-quiz/Models/ProposalStatusFilter.swift`）

絞り込み条件を表す enum。9つの選択肢（すべて、Implemented、Partially Implemented、Accepted、Active Review、Previewing、Returned、Rejected、Withdrawn）を持ち、それぞれを Payload の `where[and][N][status][contains]` クエリへ写像する。

DB上のステータスは `**Implemented (Swift 5.9)**` のような Markdown 混じりの自由文字列である。そのため完全一致ではなく `contains`（大文字小文字を無視した部分一致）で照合する。ここから2つの例外が生じる。

- **Implemented**: `not_like=partially` を併用する。"Partially implemented" も "implemented" を含むため、除外しないと両方が引っかかる。
- **Withdrawn**: `withdrawn` と `expired` の OR にする。バッジ表示側の `ProposalStatus.parse` が両者を Withdrawn として扱っており、それに揃えた。

### 検索クエリを `where[and]` 配下へ移動（`ios/se-masked-quiz/Repositories/SERepository.swift`）

テキスト検索とステータス絞り込みを併用できるよう、条件を `where[and][N]` の下に並べる形へ変更した。検索が `and[0]`、ステータスが `and[1]` に入る。変更前の検索はトップレベルの `where[or][N]` だったため、そのままではステータス条件と併用したときに OR/AND の意図が崩れる。

### 一覧画面にフィルタUIを追加（`ios/se-masked-quiz/ProposalFeature/ProposalListScreen.swift`）

- ツールバーに絞り込みメニューを追加した。既存の並び替えメニューと同じ `Menu` + `Picker` の構成に揃えている。
- フィルタ適用中はアイコンを `line.3.horizontal.decrease.circle.fill`（塗りつぶし）に変え、絞り込みが効いていることを一覧を見ずに判別できるようにした。
- フィルタ変更時は1ページ目から取得し直す。ページ番号、`hasNextPage`、`shouldLoadNextPage` もリセットする。
- 該当0件のときは `ContentUnavailableView` で空状態を示す。文言に選択中のステータス名を含める。

Swift Evolution / Swift Testing の両タブが同じ画面を共有しているため、どちらのトラックでも動作する。

## テスト

`ProposalStatusFilterTests` を新規追加し、`SERepositoryTests` にクエリ生成の検証を追加した。既存の検索クエリのテストは、上記のクエリ形状変更に合わせて期待値を更新している。

追加した検証の要点は次のとおり。

- 全 case がメニュー表示用ラベルを持つ
- `all` はクエリを生成しない
- `startingAndIndex` が条件のインデックスに反映される（検索との併用時にずれないこと）
- Implemented の `not_like` 除外、Withdrawn の OR 条件
- **フィルタのキーワードが `ProposalStatus.parse` の判定と一致する**。サーバーの `contains` / `not_like` の挙動を模した照合を行い、一覧バッジの表示分類とフィルタの絞り込み結果が食い違わないことを担保する

実行結果:

- ユニットテスト全件パス（iPhone 17 シミュレータ、`** TEST SUCCEEDED **`、失敗0件）
- `swift-complexity ios/se-masked-quiz --recursive --threshold 10` 通過
- 新規ファイルは `swift-format lint` の警告なし

## レビューポイント

1. **`SERepository.swift:170-182` のクエリ構築**。検索とステータスのインデックス採番が中心。`andIndex` は検索条件を追加したときのみ進める。
2. **`ProposalStatusFilter.swift` のキーワード選定**。`ProposalStatus.parse`（`Models/ProposalStatus.swift:24`）の判定ルールと対応が取れているかを見てほしい。片方だけ変更すると、バッジ表示とフィルタ結果がずれる。
3. **絞り込みメニューの配置**。並び替えメニューと同じ `ToolbarItemGroup` に2つ並べた。iPhone の狭い幅で窮屈でないかは実機での判断に委ねたい。

## 実サーバーでの確認

一時的な検証テストを追加して実データに対して実行し、次を確認した。検証後、テストは削除している。

- Implemented フィルタの結果に "Partially implemented" が混ざらない（`not_like` が効いている）
- Partially Implemented フィルタは "Partially" を含むものだけを返す
- 検索テキスト "actor" とステータス Implemented を併用しても、両方の条件が効く
- `all` は絞り込まずに返す

## ページネーションの不具合修正

レビュー中に「絞り込むと次のページが読み込まれない」との指摘があり、原因を特定して直した。

`shouldLoadNextPage` は false → true の遷移でのみ次ページを読むフラグだが、`reloadFromFirstPage` がこれをリセットしていなかった。一覧を下端までスクロールするとこのフラグは `true` になる。その状態で絞り込むと、置き換わった一覧でも表示中の行がすべて「末尾5件以内」に該当して `true` を代入するため、値が変化せず読み込みが発火しない。以降スクロールしても新しい行が現れないので復帰しない。

検索と並び替えでは一覧が先頭へ戻るため表面化しにくかった。ステータス絞り込みはスクロール位置に触れずツールバーから操作でき、かつ件数が大きく減るため、この条件が揃いやすい。

`reloadFromFirstPage` でフラグを `false` に戻すことで、再読み込み後に必ず遷移が発生するようにした。

## レビュー対応

- コードコメントを削除した。AGENTS.md の「コメントは書かないのが既定」に従い、追加したコメントはすべて外している。残したのはファイル先頭のヘッダー1行のみ。意図はコード自身とテスト名で表現し、制約は CI（複雑度ゲート）とテストで守る。
- テストケース名を、実装用語を混ぜた表記から、ユーザーから見た振る舞いを述べる日本語へ書き換えた（例:「startingAndIndex が条件のインデックスに反映される」→「キーワード検索と併用しても、絞り込み条件が別枠で追加される」）。失敗時のメッセージも画面上の表示名で出す。
- 同じ方針を `SERepositoryTests` にも適用し、既存の12件を含む全18件を書き換えた。**このPRの主題とは独立した変更**のため、レビュー時のノイズになるようなら別PRへ切り出す。
