### PR TITLE
機能追加: マスククイズの解答を2ステップにする（次の問題へ・自動スクロール）

### DIFF
--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -94,7 +94,8 @@ struct ProposalQuizView: View {
           quizViewModel.showQuizSelections(maskIndex: maskIndex)
         },
         isCorrect: $quizViewModel.isCorrect,
-        answers: $quizViewModel.answers
+        answers: $quizViewModel.answers,
+        scrollToMaskIndex: quizViewModel.pendingScrollMaskIndex
       )
       if quizViewModel.currentQuiz != nil {
         QuizSelectionsView(viewModel: quizViewModel)

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -91,8 +91,7 @@ struct ProposalQuizView: View {
           modalWebUrl = url
         },
         onMaskedWordTap: { maskIndex in
-          print("Tapped mask index:", maskIndex)
-          quizViewModel.showQuizSelections(index: maskIndex)
+          quizViewModel.showQuizSelections(maskIndex: maskIndex)
         },
         isCorrect: $quizViewModel.isCorrect,
         answers: $quizViewModel.answers

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -95,7 +95,8 @@ struct ProposalQuizView: View {
         },
         isCorrect: $quizViewModel.isCorrect,
         answers: $quizViewModel.answers,
-        scrollToMaskIndex: quizViewModel.pendingScrollMaskIndex
+        scrollToMaskIndex: quizViewModel.pendingScrollMaskIndex,
+        focusedMaskIndex: quizViewModel.currentQuiz?.index
       )
       if quizViewModel.currentQuiz != nil {
         QuizSelectionsView(viewModel: quizViewModel)

--- a/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
@@ -24,12 +24,32 @@ struct QuizSelectionsView: View {
             }
           }
           .frame(height: 32)
-          Button("閉じる", action: viewModel.dismissQuiz)
+          footer(for: quiz)
             .padding(AppSpacing.xs)
         }
       }
     }
     .padding()
+  }
+
+  @ViewBuilder
+  private func footer(for quiz: Quiz) -> some View {
+    if viewModel.isCorrect[quiz.index] == nil {
+      Button("閉じる", action: viewModel.dismissQuiz)
+    } else if viewModel.nextUnansweredMaskIndex != nil {
+      VStack(spacing: AppSpacing.sm) {
+        Button("次の問題へ", action: viewModel.goToNextUnansweredQuiz)
+          .buttonStyle(.borderedProminent)
+        Button("閉じる", action: viewModel.dismissQuiz)
+      }
+    } else {
+      VStack(spacing: AppSpacing.sm) {
+        Text("全問解答済み")
+          .font(AppFont.headline)
+          .foregroundStyle(SemanticColor.correct)
+        Button("閉じる", action: viewModel.dismissQuiz)
+      }
+    }
   }
 
   private func choiceState(for choice: String, quiz: Quiz) -> ChoiceState {

--- a/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
@@ -29,7 +29,13 @@ struct QuizSelectionsView: View {
         }
       }
     }
-    .padding()
+    .padding(AppSpacing.lg)
+    .sensoryFeedback(trigger: viewModel.currentQuiz.map { viewModel.isCorrect[$0.index] }) {
+      _, newValue in
+      guard let isCorrect = newValue ?? nil else { return nil }
+      return isCorrect ? .success : .error
+    }
+    .sensoryFeedback(.selection, trigger: viewModel.pendingScrollMaskIndex)
   }
 
   @ViewBuilder
@@ -39,7 +45,7 @@ struct QuizSelectionsView: View {
     } else if viewModel.nextUnansweredMaskIndex != nil {
       VStack(spacing: AppSpacing.sm) {
         Button("次の問題へ", action: viewModel.goToNextUnansweredQuiz)
-          .buttonStyle(.borderedProminent)
+          .buttonStyle(.glassProminent)
         Button("閉じる", action: viewModel.dismissQuiz)
       }
     } else {

--- a/ios/se-masked-quiz/ProposalFeature/QuizViewModel.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizViewModel.swift
@@ -12,6 +12,7 @@ final class QuizViewModel: ObservableObject {
   @Published var currentScore: ProposalScore?
   @Published var isShowingResetAlert = false
   @Published var isConfigured: Bool = false
+  @Published var pendingScrollMaskIndex: Int?
 
   // MARK: - LLM Quiz Properties (Issue #12)
   @Published var allLLMQuiz: [LLMQuiz] = []
@@ -150,9 +151,24 @@ final class QuizViewModel: ObservableObject {
     }
   }
 
-  func showQuizSelections(index: Int) {
-    guard isConfigured else { return }
-    currentQuiz = allQuiz[index]
+  func showQuizSelections(maskIndex: Int) {
+    guard isConfigured, let quiz = allQuiz.first(where: { $0.index == maskIndex }) else { return }
+    pendingScrollMaskIndex = nil
+    currentQuiz = quiz
+    isShowingQuiz = true
+  }
+
+  var nextUnansweredMaskIndex: Int? {
+    QuizNavigator.nextUnansweredMaskIndex(
+      after: currentQuiz?.index, in: allQuiz, answered: isCorrect)
+  }
+
+  func goToNextUnansweredQuiz() {
+    guard let next = nextUnansweredMaskIndex,
+      let quiz = allQuiz.first(where: { $0.index == next })
+    else { return }
+    currentQuiz = quiz
+    pendingScrollMaskIndex = next
     isShowingQuiz = true
   }
 

--- a/ios/se-masked-quiz/Services/QuizNavigator.swift
+++ b/ios/se-masked-quiz/Services/QuizNavigator.swift
@@ -1,0 +1,21 @@
+//
+//  QuizNavigator.swift
+//  se-masked-quiz
+//
+//  マスククイズを解き進める順序を決める純粋ロジック。
+//
+
+import Foundation
+
+enum QuizNavigator {
+  static func nextUnansweredMaskIndex(
+    after current: Int?,
+    in quizzes: [Quiz],
+    answered: [Int: Bool]
+  ) -> Int? {
+    let unanswered = quizzes.map(\.index).sorted().filter { answered[$0] == nil }
+    guard !unanswered.isEmpty else { return nil }
+    guard let current else { return unanswered.first }
+    return unanswered.first { $0 > current } ?? unanswered.first
+  }
+}

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -52,6 +52,7 @@ enum HTMLContent {
     @Binding var isCorrect: [Int: Bool]
     @Binding var answers: [Int: String]
     var scrollToMaskIndex: Int?
+    var focusedMaskIndex: Int?
 
     func makeUIView(context: Context) -> UIViewType {
       let view = UIViewType(
@@ -63,7 +64,8 @@ enum HTMLContent {
           htmlContent,
           isCorrect: isCorrect,
           answers: answers,
-          scrollToMaskIndex: scrollToMaskIndex
+          scrollToMaskIndex: scrollToMaskIndex,
+          focusedMaskIndex: focusedMaskIndex
         )
       }
       return view
@@ -76,7 +78,8 @@ enum HTMLContent {
           isCorrect: context.coordinator.isCorrect,
           answers: context.coordinator.answers,
           scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
-          scrollToMaskIndex: scrollToMaskIndex
+          scrollToMaskIndex: scrollToMaskIndex,
+          focusedMaskIndex: focusedMaskIndex
         )
       }
     }
@@ -95,6 +98,7 @@ enum HTMLContent {
     @Binding var isCorrect: [Int: Bool]
     @Binding var answers: [Int: String]
     var scrollToMaskIndex: Int?
+    var focusedMaskIndex: Int?
 
     func makeNSView(context: Context) -> NSViewType {
       let view = NSViewType(
@@ -106,7 +110,8 @@ enum HTMLContent {
           htmlContent,
           isCorrect: isCorrect,
           answers: answers,
-          scrollToMaskIndex: scrollToMaskIndex
+          scrollToMaskIndex: scrollToMaskIndex,
+          focusedMaskIndex: focusedMaskIndex
         )
       }
       return view
@@ -119,7 +124,8 @@ enum HTMLContent {
           isCorrect: isCorrect,
           answers: answers,
           scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
-          scrollToMaskIndex: scrollToMaskIndex
+          scrollToMaskIndex: scrollToMaskIndex,
+          focusedMaskIndex: focusedMaskIndex
         )
       }
     }
@@ -166,7 +172,8 @@ extension WKWebView {
     isCorrect: [Int: Bool],
     answers: [Int: String],
     scrollContentOffsetY: CGFloat = 0,
-    scrollToMaskIndex: Int? = nil
+    scrollToMaskIndex: Int? = nil,
+    focusedMaskIndex: Int? = nil
   ) async {
     if let url = htmlContent.url {
       load(URLRequest(url: url))
@@ -177,7 +184,8 @@ extension WKWebView {
           isCorrect: isCorrect,
           answers: answers,
           scrollContentOffsetY: scrollContentOffsetY,
-          scrollToMaskIndex: scrollToMaskIndex
+          scrollToMaskIndex: scrollToMaskIndex,
+          focusedMaskIndex: focusedMaskIndex
         ),
         baseURL: nil
       )
@@ -191,7 +199,8 @@ private func parse(
   isCorrect: [Int: Bool],
   answers: [Int: String],
   scrollContentOffsetY: CGFloat = 0,
-  scrollToMaskIndex: Int? = nil
+  scrollToMaskIndex: Int? = nil,
+  focusedMaskIndex: Int? = nil
 ) async -> String {
   let htmlContent = await html.content
   if case .url = html {
@@ -206,6 +215,7 @@ private func parse(
   let answersJSON =
     (try? jsonEncoder.encode(answers)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
   let scrollTargetJSON = scrollToMaskIndex.map(String.init) ?? "null"
+  let focusedJSON = focusedMaskIndex.map(String.init) ?? "null"
 
   // HTMLエスケープを解除
   let unescapedContent =
@@ -222,6 +232,34 @@ private func parse(
             <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.7.2/styles/atom-one-dark.min.css">
             <style>
+                :root {
+                    color-scheme: light dark;
+                    --bg: #ffffff;
+                    --fg: #1c1c1e;
+                    --code-bg: #f0f0f0;
+                    --code-fg: #9a2c1f;
+                    --mask-bg: rgba(10, 132, 255, 0.10);
+                    --mask-bg-hover: rgba(10, 132, 255, 0.20);
+                    --mask-fg: #1c1c1e;
+                    --mask-border: rgba(10, 132, 255, 0.45);
+                    --correct-bg: #2e7d32;
+                    --incorrect-bg: #c62828;
+                    --focus: #0a84ff;
+                    --focus-halo: rgba(10, 132, 255, 0.20);
+                }
+                @media (prefers-color-scheme: dark) {
+                    :root {
+                        --bg: #1c1c1e;
+                        --fg: #f2f2f7;
+                        --code-bg: #2c2c2e;
+                        --code-fg: #ff9e91;
+                        --mask-bg: rgba(10, 132, 255, 0.22);
+                        --mask-bg-hover: rgba(10, 132, 255, 0.34);
+                        --mask-fg: #f2f2f7;
+                        --mask-border: rgba(100, 180, 255, 0.60);
+                        --focus-halo: rgba(10, 132, 255, 0.28);
+                    }
+                }
                 * {
                     font-family: -apple-system, BlinkMacSystemFont, SF Mono, Menlo, monospace;
                 }
@@ -229,7 +267,9 @@ private func parse(
                     font-size: 20px;
                     line-height: 1.6;
                     padding: 16px;
-                    color: #333;
+                    background-color: var(--bg);
+                    color: var(--fg);
+                    overflow-wrap: break-word;
                 }
                 pre {
                     margin: 16px 0;
@@ -247,37 +287,57 @@ private func parse(
                 }
                 code:not(pre code) {
                     font-size: 0.9em;
-                    background: #f0f0f0;
+                    background: var(--code-bg);
                     padding: 2px 6px;
                     border-radius: 4px;
-                    color: #e06c75;
+                    color: var(--code-fg);
                 }
                 .masked-word {
-                    color: #000;
+                    color: var(--mask-fg);
+                    background-color: var(--mask-bg);
+                    border-bottom: 2px solid var(--mask-border);
                     padding: 2px 6px;
                     border-radius: 4px;
                     cursor: pointer;
                     user-select: none;
-                    display: inline-block;  /* インライン要素をブロック化してクリック領域を確保 */
-                    pointer-events: auto;   /* クリックイベントを確実に有効化 */
+                    display: inline-block;
+                    position: relative;
+                    touch-action: manipulation;
+                    -webkit-tap-highlight-color: transparent;
                 }
                 .masked-word.correct {
                     color: #fff;
-                    background-color: #4CAF50;
+                    background-color: var(--correct-bg);
+                    border-bottom-color: transparent;
                 }
                 .masked-word.incorrect {
                     color: #fff;
-                    background-color: #f44336;
+                    background-color: var(--incorrect-bg);
+                    border-bottom-color: transparent;
                 }
-                .masked-word:hover {
-                    color: #000;
-                    background-color: #ccc;
+                .masked-word.current {
+                    outline: 3px solid var(--focus);
+                    outline-offset: 2px;
+                    box-shadow: 0 0 0 7px var(--focus-halo);
+                    z-index: 1;
                 }
-                .masked-word.correct:hover {
-                    background-color: #45a049;
+                @keyframes mask-pulse {
+                    0%   { transform: scale(1); }
+                    35%  { transform: scale(1.08); }
+                    100% { transform: scale(1); }
                 }
-                .masked-word.incorrect:hover {
-                    background-color: #da190b;
+                .masked-word.current.pulse {
+                    animation: mask-pulse 450ms cubic-bezier(0.34, 1.56, 0.64, 1) 2;
+                }
+                @media (prefers-reduced-motion: reduce) {
+                    .masked-word.current.pulse { animation: none; }
+                    .masked-word.current { box-shadow: 0 0 0 10px var(--focus-halo); }
+                }
+                @media (hover: hover) {
+                    .masked-word:hover { background-color: var(--mask-bg-hover); }
+                }
+                .masked-word:active {
+                    transform: scale(0.97);
                 }
             </style>
             <script>
@@ -286,6 +346,7 @@ private func parse(
                 const answersMap = \(answersJSON);
                 const initialScrollY = \(scrollContentOffsetY);
                 const scrollTargetIndex = \(scrollTargetJSON);
+                const focusedIndex = \(focusedJSON);
                 
                 function wrapMaskedWords() {
                     const text = document.body.innerHTML;
@@ -296,8 +357,11 @@ private func parse(
                         const isCorrect = isAnswered ? isCorrectMap[index.toString()] : false;
                         const answer = isAnswered ? answersMap[index.toString()] : '';
                         let message = isAnswered ? answer : match;
-                        const className = isAnswered ? (isCorrect ? 'masked-word correct' : 'masked-word incorrect') : 'masked-word';
-                        return `<span class="${className}" data-mask-index="${index}">${message}</span>`;
+                        const classes = ['masked-word'];
+                        if (isAnswered) { classes.push(isCorrect ? 'correct' : 'incorrect'); }
+                        if (index === focusedIndex) { classes.push('current'); }
+                        if (index === scrollTargetIndex) { classes.push('pulse'); }
+                        return `<span class="${classes.join(' ')}" data-mask-index="${index}">${message}</span>`;
                     });
                     document.body.innerHTML = wrappedText;
                     

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -51,6 +51,7 @@ enum HTMLContent {
     let onMaskedWordTap: (Int) -> Void
     @Binding var isCorrect: [Int: Bool]
     @Binding var answers: [Int: String]
+    var scrollToMaskIndex: Int?
 
     func makeUIView(context: Context) -> UIViewType {
       let view = UIViewType(
@@ -61,7 +62,8 @@ enum HTMLContent {
         await view.loadHtmlContent(
           htmlContent,
           isCorrect: isCorrect,
-          answers: answers
+          answers: answers,
+          scrollToMaskIndex: scrollToMaskIndex
         )
       }
       return view
@@ -69,12 +71,12 @@ enum HTMLContent {
 
     func updateUIView(_ uiView: UIViewType, context: Context) {
       Task {
-        print("contentoffsetY in updateUIView: \(context.coordinator.scrollContentOffsetY)")
         await uiView.loadHtmlContent(
           htmlContent,
           isCorrect: context.coordinator.isCorrect,
           answers: context.coordinator.answers,
-          scrollContentOffsetY: context.coordinator.scrollContentOffsetY
+          scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
+          scrollToMaskIndex: scrollToMaskIndex
         )
       }
     }
@@ -92,6 +94,7 @@ enum HTMLContent {
     let onMaskedWordTap: (Int) -> Void
     @Binding var isCorrect: [Int: Bool]
     @Binding var answers: [Int: String]
+    var scrollToMaskIndex: Int?
 
     func makeNSView(context: Context) -> NSViewType {
       let view = NSViewType(
@@ -102,7 +105,8 @@ enum HTMLContent {
         await view.loadHtmlContent(
           htmlContent,
           isCorrect: isCorrect,
-          answers: answers
+          answers: answers,
+          scrollToMaskIndex: scrollToMaskIndex
         )
       }
       return view
@@ -114,7 +118,8 @@ enum HTMLContent {
           htmlContent,
           isCorrect: isCorrect,
           answers: answers,
-          scrollContentOffsetY: context.coordinator.scrollContentOffsetY
+          scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
+          scrollToMaskIndex: scrollToMaskIndex
         )
       }
     }
@@ -160,7 +165,8 @@ extension WKWebView {
     _ htmlContent: HTMLContent,
     isCorrect: [Int: Bool],
     answers: [Int: String],
-    scrollContentOffsetY: CGFloat = 0
+    scrollContentOffsetY: CGFloat = 0,
+    scrollToMaskIndex: Int? = nil
   ) async {
     if let url = htmlContent.url {
       load(URLRequest(url: url))
@@ -170,7 +176,8 @@ extension WKWebView {
           html: htmlContent,
           isCorrect: isCorrect,
           answers: answers,
-          scrollContentOffsetY: scrollContentOffsetY
+          scrollContentOffsetY: scrollContentOffsetY,
+          scrollToMaskIndex: scrollToMaskIndex
         ),
         baseURL: nil
       )
@@ -183,7 +190,8 @@ private func parse(
   html: HTMLContent,
   isCorrect: [Int: Bool],
   answers: [Int: String],
-  scrollContentOffsetY: CGFloat = 0
+  scrollContentOffsetY: CGFloat = 0,
+  scrollToMaskIndex: Int? = nil
 ) async -> String {
   let htmlContent = await html.content
   if case .url = html {
@@ -197,6 +205,7 @@ private func parse(
     (try? jsonEncoder.encode(isCorrect)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
   let answersJSON =
     (try? jsonEncoder.encode(answers)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+  let scrollTargetJSON = scrollToMaskIndex.map(String.init) ?? "null"
 
   // HTMLエスケープを解除
   let unescapedContent =
@@ -276,6 +285,7 @@ private func parse(
                 const isCorrectMap = \(isCorrectJSON);
                 const answersMap = \(answersJSON);
                 const initialScrollY = \(scrollContentOffsetY);
+                const scrollTargetIndex = \(scrollTargetJSON);
                 
                 function wrapMaskedWords() {
                     const text = document.body.innerHTML;
@@ -292,9 +302,15 @@ private func parse(
                     document.body.innerHTML = wrappedText;
                     
                     console.log('Total masked groups:', currentIndex);
-                    
-                    // Set initial scroll position after content is loaded
-                    window.scrollTo(0, initialScrollY);
+
+                    const scrollTarget = scrollTargetIndex === null
+                        ? null
+                        : document.querySelector('[data-mask-index="' + scrollTargetIndex + '"]');
+                    if (scrollTarget) {
+                        scrollTarget.scrollIntoView({ block: 'center' });
+                    } else {
+                        window.scrollTo(0, initialScrollY);
+                    }
                 }
                 window.addEventListener('load', wrapMaskedWords);
             </script>

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -72,16 +72,7 @@ enum HTMLContent {
     }
 
     func updateUIView(_ uiView: UIViewType, context: Context) {
-      Task {
-        await uiView.loadHtmlContent(
-          htmlContent,
-          isCorrect: context.coordinator.isCorrect,
-          answers: context.coordinator.answers,
-          scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
-          scrollToMaskIndex: scrollToMaskIndex,
-          focusedMaskIndex: focusedMaskIndex
-        )
-      }
+      applyQuizState(to: uiView, coordinator: context.coordinator)
     }
   }
 #endif
@@ -118,21 +109,25 @@ enum HTMLContent {
     }
 
     func updateNSView(_ nsView: WKWebView, context: Context) {
-      Task {
-        await nsView.loadHtmlContent(
-          htmlContent,
-          isCorrect: isCorrect,
-          answers: answers,
-          scrollContentOffsetY: context.coordinator.scrollContentOffsetY,
-          scrollToMaskIndex: scrollToMaskIndex,
-          focusedMaskIndex: focusedMaskIndex
-        )
-      }
+      applyQuizState(to: nsView, coordinator: context.coordinator)
     }
   }
 #endif
 
 extension DefaultWebView {
+
+  /// 回答のたびに全リロードすると白いちらつきとスクロール位置の復元が走るため、
+  /// 初回ロード後は JavaScript で DOM を部分更新する。
+  fileprivate func applyQuizState(to webView: WKWebView, coordinator: Coordinator) {
+    guard case .string = htmlContent, coordinator.didLoadInitialContent else { return }
+    let script = quizStateScript(
+      isCorrect: isCorrect,
+      answers: answers,
+      focusedMaskIndex: focusedMaskIndex,
+      scrollToMaskIndex: scrollToMaskIndex
+    )
+    webView.evaluateJavaScript(script)
+  }
 
   func makeCoordinator() -> Coordinator {
     .init(
@@ -147,6 +142,7 @@ extension DefaultWebView {
     let onNavigate: (URL) -> Void
     let onMaskedWordTap: (Int) -> Void
     var scrollContentOffsetY: CGFloat
+    var didLoadInitialContent = false
     @Binding var isCorrect: [Int: Bool]
     @Binding var answers: [Int: String]
 
@@ -193,6 +189,23 @@ extension WKWebView {
   }
 }
 
+private func jsonObject<Value: Encodable>(_ dictionary: [Int: Value]) -> String {
+  (try? JSONEncoder().encode(dictionary)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+}
+
+func quizStateScript(
+  isCorrect: [Int: Bool],
+  answers: [Int: String],
+  focusedMaskIndex: Int?,
+  scrollToMaskIndex: Int?
+) -> String {
+  """
+  window.applyQuizState(\(jsonObject(isCorrect)), \(jsonObject(answers)), \
+  \(focusedMaskIndex.map(String.init) ?? "null"), \
+  \(scrollToMaskIndex.map(String.init) ?? "null"));
+  """
+}
+
 // ref: https://designcode.io/swiftui-advanced-handbook-code-highlighting-in-a-webview
 private func parse(
   html: HTMLContent,
@@ -208,12 +221,8 @@ private func parse(
     return htmlContent
   }
 
-  // Convert dictionaries to JSON
-  let jsonEncoder = JSONEncoder()
-  let isCorrectJSON =
-    (try? jsonEncoder.encode(isCorrect)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
-  let answersJSON =
-    (try? jsonEncoder.encode(answers)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+  let isCorrectJSON = jsonObject(isCorrect)
+  let answersJSON = jsonObject(answers)
   let scrollTargetJSON = scrollToMaskIndex.map(String.init) ?? "null"
   let focusedJSON = focusedMaskIndex.map(String.init) ?? "null"
 
@@ -342,40 +351,59 @@ private func parse(
             </style>
             <script>
                 let currentIndex = 0;
-                const isCorrectMap = \(isCorrectJSON);
-                const answersMap = \(answersJSON);
                 const initialScrollY = \(scrollContentOffsetY);
-                const scrollTargetIndex = \(scrollTargetJSON);
-                const focusedIndex = \(focusedJSON);
-                
+                let quizState = {
+                    isCorrect: \(isCorrectJSON),
+                    answers: \(answersJSON),
+                    focused: \(focusedJSON),
+                    scrollTarget: \(scrollTargetJSON)
+                };
+                let appliedScrollTarget = null;
+
                 function wrapMaskedWords() {
                     const text = document.body.innerHTML;
                     const pattern = /(＿)+/g;
                     const wrappedText = text.replace(pattern, function(match) {
                         const index = currentIndex++;
-                        const isAnswered = isCorrectMap.hasOwnProperty(index.toString());
-                        const isCorrect = isAnswered ? isCorrectMap[index.toString()] : false;
-                        const answer = isAnswered ? answersMap[index.toString()] : '';
-                        let message = isAnswered ? answer : match;
-                        const classes = ['masked-word'];
-                        if (isAnswered) { classes.push(isCorrect ? 'correct' : 'incorrect'); }
-                        if (index === focusedIndex) { classes.push('current'); }
-                        if (index === scrollTargetIndex) { classes.push('pulse'); }
-                        return `<span class="${classes.join(' ')}" data-mask-index="${index}">${message}</span>`;
+                        return `<span class="masked-word" data-mask-index="${index}" data-placeholder="${match}">${match}</span>`;
                     });
                     document.body.innerHTML = wrappedText;
-                    
-                    console.log('Total masked groups:', currentIndex);
-
-                    const scrollTarget = scrollTargetIndex === null
-                        ? null
-                        : document.querySelector('[data-mask-index="' + scrollTargetIndex + '"]');
-                    if (scrollTarget) {
-                        scrollTarget.scrollIntoView({ block: 'center' });
-                    } else {
+                    renderQuizState();
+                    if (quizState.scrollTarget === null) {
                         window.scrollTo(0, initialScrollY);
                     }
                 }
+
+                function renderQuizState() {
+                    document.querySelectorAll('.masked-word').forEach(function(el) {
+                        const key = el.dataset.maskIndex;
+                        const answered = Object.prototype.hasOwnProperty.call(quizState.isCorrect, key);
+                        el.classList.toggle('correct', answered && quizState.isCorrect[key]);
+                        el.classList.toggle('incorrect', answered && !quizState.isCorrect[key]);
+                        el.classList.toggle('current', String(quizState.focused) === key);
+                        el.textContent = answered ? quizState.answers[key] : el.dataset.placeholder;
+                    });
+                    if (quizState.scrollTarget === null || quizState.scrollTarget === appliedScrollTarget) {
+                        return;
+                    }
+                    const target = document.querySelector('[data-mask-index="' + quizState.scrollTarget + '"]');
+                    if (!target) { return; }
+                    appliedScrollTarget = quizState.scrollTarget;
+                    target.scrollIntoView({ block: 'center' });
+                    target.classList.remove('pulse');
+                    void target.offsetWidth;
+                    target.classList.add('pulse');
+                }
+
+                window.applyQuizState = function(isCorrect, answers, focused, scrollTarget) {
+                    quizState = {
+                        isCorrect: isCorrect,
+                        answers: answers,
+                        focused: focused,
+                        scrollTarget: scrollTarget
+                    };
+                    renderQuizState();
+                };
                 window.addEventListener('load', wrapMaskedWords);
             </script>
         </HEAD>
@@ -403,6 +431,10 @@ private func parse(
 }
 
 extension DefaultWebView.Coordinator: WKNavigationDelegate {
+  func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+    didLoadInitialContent = true
+  }
+
   func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async
     -> WKNavigationActionPolicy
   {

--- a/ios/se-masked-quizTests/QuizNavigatorTests.swift
+++ b/ios/se-masked-quizTests/QuizNavigatorTests.swift
@@ -1,0 +1,129 @@
+import Testing
+@testable import se_masked_quiz
+
+private func makeQuizzes(_ indices: [Int]) -> [Quiz] {
+  indices.map {
+    Quiz(
+      id: "q\($0)",
+      proposalId: "0001",
+      index: $0,
+      answer: "correct",
+      choices: ["wrong1", "wrong2"]
+    )
+  }
+}
+
+@Suite("マスククイズの出題順")
+struct QuizNavigatorTests {
+
+  @Test("解答した次の問題へ進む")
+  func advancesToNextQuestion() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 0, in: makeQuizzes([0, 1, 2, 3]), answered: [0: true])
+    #expect(result == 1)
+  }
+
+  @Test("不正解でも解答済みとして扱い、その次へ進む")
+  func treatsIncorrectAnswerAsAnswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 0, in: makeQuizzes([0, 1, 2]), answered: [0: false])
+    #expect(result == 1)
+  }
+
+  @Test("すでに解答済みの問題は飛ばす")
+  func skipsAnsweredQuestions() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 0, in: makeQuizzes([0, 1, 2, 3]), answered: [0: true, 1: true, 2: true])
+    #expect(result == 3)
+  }
+
+  @Test("まだ何も解いていないときは最初の問題を返す")
+  func returnsFirstQuestionWhenNothingAnswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: nil, in: makeQuizzes([0, 1, 2]), answered: [:])
+    #expect(result == 0)
+  }
+
+  @Test("最後まで進んだら、飛ばした問題へ戻る")
+  func wrapsAroundToSkippedQuestion() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 3, in: makeQuizzes([0, 1, 2, 3]), answered: [2: true, 3: true])
+    #expect(result == 0)
+  }
+
+  @Test("途中から解き始めても残りの問題に到達できる")
+  func reachesRemainingQuestionsWhenStartingMidway() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 3, in: makeQuizzes([0, 1, 2, 3, 4, 5]), answered: [3: true])
+    #expect(result == 4)
+  }
+
+  @Test("問題番号が連続していなくても順番に進む")
+  func advancesThroughNonContiguousIndices() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 3, in: makeQuizzes([3, 7, 10]), answered: [3: true])
+    #expect(result == 7)
+  }
+
+  @Test("問題の並び順が番号順でなくても本文の順に進む")
+  func followsDocumentOrderRegardlessOfArrayOrder() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 1, in: makeQuizzes([5, 1, 3]), answered: [1: true])
+    #expect(result == 3)
+  }
+
+  @Test("問題が1つも無いときは次へ進まない")
+  func returnsNilWhenNoQuestions() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(after: nil, in: [], answered: [:])
+    #expect(result == nil)
+  }
+
+  @Test("全問解答済みのときは次へ進まない")
+  func returnsNilWhenAllAnswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 2, in: makeQuizzes([0, 1, 2]), answered: [0: true, 1: true, 2: false])
+    #expect(result == nil)
+  }
+
+  @Test("現在位置が存在しない番号でも未解答の問題へ進める")
+  func wrapsWhenCurrentIndexIsUnknown() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 99, in: makeQuizzes([0, 1, 2]), answered: [:])
+    #expect(result == 0)
+  }
+
+  @Test("現在位置が存在しない番号で全問解答済みなら進まない")
+  func returnsNilWhenCurrentIndexIsUnknownAndAllAnswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 99, in: makeQuizzes([0, 1]), answered: [0: true, 1: true])
+    #expect(result == nil)
+  }
+
+  @Test("問題が1つだけで未解答ならその問題を返す")
+  func returnsOnlyQuestionWhenUnanswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: nil, in: makeQuizzes([0]), answered: [:])
+    #expect(result == 0)
+  }
+
+  @Test("残り1問が現在表示中のときはその問題自身を返す")
+  func returnsItselfWhenOnlyRemainingQuestionIsCurrent() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 1, in: makeQuizzes([0, 1]), answered: [0: true])
+    #expect(result == 1)
+  }
+
+  @Test("最後の問題を解いた直後は次へ進まない")
+  func returnsNilAfterAnsweringLastQuestion() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 1, in: makeQuizzes([0, 1]), answered: [0: true, 1: true])
+    #expect(result == nil)
+  }
+
+  @Test("先頭の問題だけ未解答のとき末尾から先頭へ戻る")
+  func wrapsFromLastToFirstUnanswered() {
+    let result = QuizNavigator.nextUnansweredMaskIndex(
+      after: 2, in: makeQuizzes([0, 1, 2]), answered: [1: true, 2: true])
+    #expect(result == 0)
+  }
+}

--- a/ios/se-masked-quizTests/QuizViewModelTests.swift
+++ b/ios/se-masked-quizTests/QuizViewModelTests.swift
@@ -178,7 +178,7 @@ final class QuizViewModelTests: XCTestCase {
     try await Task.sleep(nanoseconds: 100_000_000)
 
     // When
-    sut.showQuizSelections(index: 0)
+    sut.showQuizSelections(maskIndex: 0)
     sut.selectAnswer("Swift")
 
     // Then
@@ -212,7 +212,7 @@ final class QuizViewModelTests: XCTestCase {
     try await Task.sleep(nanoseconds: 100_000_000)
 
     // When
-    sut.showQuizSelections(index: 0)
+    sut.showQuizSelections(maskIndex: 0)
     sut.selectAnswer("Java")
 
     // Then
@@ -245,7 +245,7 @@ final class QuizViewModelTests: XCTestCase {
     // Wait for quiz to load
     try await Task.sleep(nanoseconds: 100_000_000)
 
-    sut.showQuizSelections(index: 0)
+    sut.showQuizSelections(maskIndex: 0)
     XCTAssertNotNil(sut.currentQuiz)
 
     // When
@@ -273,7 +273,7 @@ final class QuizViewModelTests: XCTestCase {
     await sut.configure()
     try await Task.sleep(nanoseconds: 100_000_000)
 
-    sut.showQuizSelections(index: 0)
+    sut.showQuizSelections(maskIndex: 0)
     sut.selectAnswer("Swift")
 
     // Verify initial state
@@ -607,5 +607,120 @@ final class QuizViewModelTests: XCTestCase {
     XCTAssertTrue(sut.allLLMQuiz.isEmpty)
     XCTAssertNil(sut.llmQuizScore)
     XCTAssertNil(mockLLMQuizzes[proposalId])
+  }
+
+  // MARK: - Mask Quiz Navigation
+
+  private func makeMaskQuiz(index: Int, proposalId: String = "0001") -> Quiz {
+    Quiz(
+      id: "q\(index)", proposalId: proposalId, index: index, answer: "correct",
+      choices: ["wrong1", "wrong2"])
+  }
+
+  private func configuredViewModel(
+    maskIndices: [Int], proposalId: String = "0001"
+  ) async throws -> QuizViewModel {
+    setQuizzes(maskIndices.map { makeMaskQuiz(index: $0, proposalId: proposalId) }, for: proposalId)
+    let viewModel = QuizViewModel(proposalId: proposalId, quizRepository: mockRepository)
+    await viewModel.configure()
+    try await Task.sleep(nanoseconds: 100_000_000)
+    return viewModel
+  }
+
+  func testShowQuizSelections_OutOfBounds_DoesNotCrash() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1])
+
+    sut.showQuizSelections(maskIndex: 99)
+
+    XCTAssertNil(sut.currentQuiz)
+  }
+
+  func testShowQuizSelections_WithValidMaskIndex_SetsCurrentQuiz() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1, 2])
+
+    sut.showQuizSelections(maskIndex: 1)
+
+    XCTAssertEqual(sut.currentQuiz?.index, 1)
+  }
+
+  func testShowQuizSelections_ClearsPendingScrollMaskIndex() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1, 2])
+    sut.pendingScrollMaskIndex = 2
+
+    sut.showQuizSelections(maskIndex: 0)
+
+    XCTAssertNil(sut.pendingScrollMaskIndex)
+  }
+
+  func testShowQuizSelections_BeforeConfigure_DoesNothing() async throws {
+    setQuizzes([makeMaskQuiz(index: 0)], for: "0001")
+    sut = QuizViewModel(proposalId: "0001", quizRepository: mockRepository)
+
+    sut.showQuizSelections(maskIndex: 0)
+
+    XCTAssertNil(sut.currentQuiz)
+  }
+
+  func testGoToNextUnansweredQuiz_SetsCurrentQuizAndPendingScroll() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1, 2])
+    sut.showQuizSelections(maskIndex: 0)
+    sut.selectAnswer("correct")
+
+    sut.goToNextUnansweredQuiz()
+
+    XCTAssertEqual(sut.currentQuiz?.index, 1)
+    XCTAssertEqual(sut.pendingScrollMaskIndex, 1)
+  }
+
+  func testGoToNextUnansweredQuiz_AfterAnswering_MovesToNextUnanswered() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1, 2])
+    sut.showQuizSelections(maskIndex: 0)
+    sut.selectAnswer("correct")
+    sut.goToNextUnansweredQuiz()
+    sut.selectAnswer("wrong1")
+
+    sut.goToNextUnansweredQuiz()
+
+    XCTAssertEqual(sut.currentQuiz?.index, 2)
+  }
+
+  func testGoToNextUnansweredQuiz_WhenAllAnswered_DoesNothing() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1])
+    sut.showQuizSelections(maskIndex: 0)
+    sut.selectAnswer("correct")
+    sut.goToNextUnansweredQuiz()
+    sut.selectAnswer("correct")
+
+    sut.goToNextUnansweredQuiz()
+
+    XCTAssertEqual(sut.currentQuiz?.index, 1)
+    XCTAssertEqual(sut.pendingScrollMaskIndex, 1)
+  }
+
+  func testGoToNextUnansweredQuiz_WhenNoQuizzes_DoesNothing() async throws {
+    sut = try await configuredViewModel(maskIndices: [])
+
+    sut.goToNextUnansweredQuiz()
+
+    XCTAssertNil(sut.currentQuiz)
+    XCTAssertNil(sut.pendingScrollMaskIndex)
+  }
+
+  func testNextUnansweredMaskIndex_WhenSomeUnanswered_ReturnsNext() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1, 2])
+    sut.showQuizSelections(maskIndex: 0)
+    sut.selectAnswer("correct")
+
+    XCTAssertEqual(sut.nextUnansweredMaskIndex, 1)
+  }
+
+  func testNextUnansweredMaskIndex_WhenAllAnswered_ReturnsNil() async throws {
+    sut = try await configuredViewModel(maskIndices: [0, 1])
+    sut.showQuizSelections(maskIndex: 0)
+    sut.selectAnswer("correct")
+    sut.goToNextUnansweredQuiz()
+    sut.selectAnswer("correct")
+
+    XCTAssertNil(sut.nextUnansweredMaskIndex)
   }
 }


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## 概要

マスククイズを解く操作を、1問あたり6ステップから **2ステップ（選ぶ→次へ）** に短縮した。マスクを探すためのスクロール操作が不要になる。

これは Issue #59（text to speech）のディスカバリから生まれた変更である。#59 は解決策の形で起票されていたため課題へ引き戻したところ、本当の問題は「解答が途切れること」だと判明した。その主因が音声の不在なのか、ナビゲーションの不在なのかを切り分けるため、**まず安い方（ナビゲーション）を実装して確かめる**のが本PRの位置づけになる。

## 解決する課題

改修前は1問ごとに次の操作を要していた。

1. 長い英文をスクロールして次のマスクを目で探す
2. タップする
3. 選択肢を選ぶ
4. 正誤の表示を見る
5. 「閉じる」を押す
6. 1に戻る

このうち「探す」と「閉じる」は解答の本質ではない。流れが無いのは体感ではなく構造上の事実である。

## 主な変更点

### `QuizNavigator` を新設（`Services/QuizNavigator.swift`）

次に解くべきマスクを決める純粋関数。View から分離してテスト可能にした。

```swift
let unanswered = quizzes.map(\.index).sorted().filter { answered[$0] == nil }
guard !unanswered.isEmpty else { return nil }
guard let current else { return unanswered.first }
return unanswered.first { $0 > current } ?? unanswered.first
```

最終行が循環の仕様を担う。現在位置より後ろを探し、無ければ先頭へ戻るため、**順不同に解いても全問に到達できる**。不正解も解答済みとして扱う（`isCorrect` にキーが入る）ので、間違えた問題を繰り返さない。

### 回答のたびの全リロードをやめ、DOM を差分更新する

**当初は既存の再読み込みに相乗りする設計にしていたが、UI/UX の専門レビューで方針が誤りだと判明したため作り直した。**

WebView は回答のたびに `loadHTMLString` で HTML 全体を読み直しており、白いちらつき・`hljs.highlightAll()` の再実行・スクロール位置の復元が毎回走っていた。「次の問題へ」の追加でこの再読み込みが**1回増えた**ため、滑らかにするという目的に逆行していた。

初回ロード後は `evaluateJavaScript` で DOM を部分更新する。設計時に `evaluateJavaScript` を「再読み込みと競合する」として却下していたが、**リロード自体を廃止すれば競合する相手がいない**。WKWebView の参照は `updateUIView` の引数で渡るため保持は不要で、初回ロードとの協調は Coordinator のフラグ1つで足りた。

JS は状態保持と描画を分離し、`wrapMaskedWords` は素の span 生成のみを担う。初回ロードと差分更新が同じ描画関数を通るため表示がずれない。

- 元テキストを `data-placeholder` に保存し、リセット時に未解答へ戻せるようにした
- `appliedScrollTarget` で同じ位置への再スクロールとパルス再生を抑える。解答のたびに再生されるとノイズになるため
- URLプレビュー用途（`ProposalListScreen`）には JS を送らない。従来そちらも状態変化のたびにリロードされていた副作用も消える

### スクロール先の注入

```javascript
const scrollTarget = scrollTargetIndex === null
    ? null
    : document.querySelector('[data-mask-index="' + scrollTargetIndex + '"]');
if (scrollTarget) {
    scrollTarget.scrollIntoView({ block: 'center' });
} else {
    window.scrollTo(0, initialScrollY);
}
```

注入点は `wrapMaskedWords()` 内、マスクのDOM生成が完了した直後。ここより前では `[data-mask-index]` がまだ存在しない。

`block: 'center'` としたのは、マスクの前後を読んでから解答できるようにするため。上端寄せだと直前の文脈が画面外に出る。`behavior` は指定せず即時にする。

### 既存のクラッシュリスクを解消

`showQuizSelections(index:)` は `allQuiz[index]` と配列添字で参照しており、「マスクindex == 配列位置」を暗黙に仮定していた。**範囲外indexで実際にクラッシュすることをテストで確認した上で**、`Quiz.index` を鍵とした参照に変更した。

既存テスト4件がシグネチャ変更で失敗したが、いずれもマスクを1つだけ持つケースで配列位置とマスクindexが一致していたため、ラベル変更のみで挙動は変わらない。裏を返すと、テストが1マスクのケースしか扱っていなかったためにこの前提の破綻が表面化していなかった。

### `pendingScrollMaskIndex` はタップ時にクリアする

マスクを直接タップした経路では `nil` に戻す。クリアしないと、ユーザーが手動でスクロールして別の位置を読んでいる最中の再描画で、前回の遷移先へ引き戻される。

## テスト

新規26件を追加し、既存18件と合わせて全件グリーン。

**`QuizNavigatorTests`（16件・Swift Testing）**: 循環、不連続なマスク番号、配列順への非依存、全問解答済み、境界値を網羅した。特に次の4件は仕様を固定する意図がある。

- 不正解でも解答済みとして扱い、その次へ進む
- 最後まで進んだら、飛ばした問題へ戻る
- 問題の並び順が番号順でなくても本文の順に進む
- 残り1問が現在表示中のときはその問題自身を返す

**`QuizViewModelTests`（10件追加・XCTest）**: 既存18件と同じ流儀に合わせた。`testShowQuizSelections_ClearsPendingScrollMaskIndex` が引き戻し不具合を、`testShowQuizSelections_OutOfBounds_DoesNotCrash` がクラッシュ解消を担保する。

**検証結果**

- ユニットテスト全件パス（iPhone 17 シミュレータ）
- macOS ビルド成功（`DefaultWebView` は iOS/macOS で実装が分かれるため両方確認）
- `swift-complexity --threshold 10` 通過
- `swift-format lint` クリーン
- 生成される JavaScript を `node --check` で構文検証し、セレクタが `[data-mask-index="7"]` になることを確認

## レビュー対応: 解答中のマスクの強調表示と触覚フィードバック

レビューで「今フォーカスが当たっている穴埋めがどれか分かりにくい」との指摘を受けて追加した。自動スクロールで勝手に移動する分、移動先のどれが対象なのかが以前より分かりにくくなっており、フォーカス表示は自動スクロールとセットで必要な要素だった。

- マスクに4状態（未解答・正解・不正解・フォーカス中）を持たせた。フォーカスは `outline` と `box-shadow` のリングで示す。`outline` はボックスサイズに影響しないため行送りが崩れない
- 移動時に2回パルスさせる。`prefers-reduced-motion` では動きを止めてリングを強調する
- 未解答マスクは背景も枠線も無く本文に埋もれていたため、薄い青背景と下線を付けた
- 触覚は `.sensoryFeedback` で正誤に `success`/`error`、移動に `selection` を割り当てた。UIKit を持ち込まずに済み、macOS では自動的に無効になる
- 「次の問題へ」は `.borderedProminent` から `.glassProminent` へ変更した。`LLMQuizGenerationSheet.swift:86` に前例があり、画面全体が Liquid Glass 基調のため

### 併せて修正した既存の不具合

UI/UX の専門レビューで判明したもので、本機能とは独立に壊れていた。

- **ダークモードの破綻**: `body` に背景色指定が無く `.masked-word` が `color: #000` だったため、ダークモードでは本文がほぼ読めなかった。`color-scheme` とトークンを導入して両モードに対応した
- **コントラスト不足**: 正解 2.78:1 / 不正解 3.68:1 / インラインコード 2.81:1 といずれも WCAG AA 未達だった。基準を満たす値へ置き換えた

## レビューポイント

1. **`DefaultWebView.swift` の JS 注入部分**。`wrapMaskedWords()` 内、マスクのDOM生成直後に置いている。ここより前では `[data-mask-index]` がまだ存在しない
2. **`scrollToMaskIndex` を4メソッドすべてに通しているか**。iOS/macOS それぞれの make/update で、1箇所でも漏れると片方だけ動かなくなる
3. **`QuizNavigator` の循環仕様**。順不同に解いた場合の到達性がこれに依存する

## 未実施の確認（マージ前にお願いしたいこと）

シミュレータの UI 自動操作が使えない環境のため、**実機での目視確認ができていない**。特に次の2点は自動テストで代替できない。

1. **一度もスクロールせずに解き切れるか**。移動先のマスクが画面中央に来て、リングとパルスで対象が分かるか
2. **選択肢をタップしたときに白いちらつきが起きないか**（差分更新が効いているかの確認）
3. **「次へ」で移動後に手動スクロールし、別のマスクをタップしたとき、前の位置へ引き戻されないか**
4. **ダークモードで本文とマスクが読めるか**
5. **触覚が正誤で鳴り分けるか**

また `.buttonStyle(.borderedProminent)` はこのコードベースで初めての使用になる（既存は `.plain` と `.borderless` のみ）。この画面だけ浮いて見えるようなら調整する。

## 本PRに含めなかった専門レビューの指摘

別PRで対応する。

- **パネルの再設計**: 3状態で高さが変わるため解答するとボタン位置がずれる。`.frame(height: 32)` は Dynamic Type で破綻し下のボタンと重なる。残り問題数も表示されていない（現状のスコアは解答済みのみを母数にするため「1/1問正解 100%」と出る）
- **アクセシビリティ**: マスクが `<span>` のままで `role` も `tabindex` も無いため、**VoiceOver からクイズを開始できない**。機能全体がスクリーンリーダーで使えない状態であり、優先度は高い
- WebView のズーム禁止（`user-scalable=no`）、マスク生成が CDN 取得完了待ちになっている点、タップ領域が 44pt 未満である点

## Issue #59 との関係

本PRは #59 を閉じない。マージ後に提案を3本ほど解いていただき、**「まだ音声が欲しいと感じるか」** で判断する。

- 感じない → #59 は No-Go としてクローズ
- 感じる → 残った不足点が TTS の要件になる

どちらに転んでも無駄にならない。TTS が不要と分かれば最も高価な仮説を最も安く否定でき、必要と分かっても「次のマスクへ進む」機構は読み上げ実装の土台としてそのまま使える。
