### PR TITLE
不具合修正: VoiceOverからマスククイズを操作できるようにし、解答画面を日英対応する

### DIFF
--- a/ios/se-masked-quiz.xcodeproj/project.pbxproj
+++ b/ios/se-masked-quiz.xcodeproj/project.pbxproj
@@ -217,11 +217,12 @@
 				};
 			};
 			buildConfigurationList = D3921FD92D252F0A008C3732 /* Build configuration list for PBXProject "se-masked-quiz" */;
-			developmentRegion = en;
+			developmentRegion = ja;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 				Base,
+				ja,
 			);
 			mainGroup = D3921FD52D252F0A008C3732;
 			minimizedProjectReferenceProxies = 1;

--- a/ios/se-masked-quiz/Localizable.xcstrings
+++ b/ios/se-masked-quiz/Localizable.xcstrings
@@ -1,0 +1,259 @@
+{
+  "sourceLanguage" : "ja",
+  "strings" : {
+    "(%lld/%lld問正解)" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "(%lld/%lld correct)"
+          }
+        }
+      }
+    },
+    "LLMクイズを生成するには、設定画面からモデルをダウンロードしてください。" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To generate LLM quizzes, download a model from Settings."
+          }
+        }
+      }
+    },
+    "このプロポーザルのクイズの進捗をリセットしますか？\nこの操作は取り消せません。" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset your quiz progress for this proposal?\nThis action cannot be undone."
+          }
+        }
+      }
+    },
+    "キャンセル" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        }
+      }
+    },
+    "クイズをリセット" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset quiz"
+          }
+        }
+      }
+    },
+    "クイズを生成" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Generate quiz"
+          }
+        }
+      }
+    },
+    "不正解、答えは %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incorrect. The answer is %@"
+          }
+        }
+      }
+    },
+    "不正解..." : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Incorrect..."
+          }
+        }
+      }
+    },
+    "依存グラフ" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dependency graph"
+          }
+        }
+      }
+    },
+    "先に読むと理解しやすい提案" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Proposals worth reading first"
+          }
+        }
+      }
+    },
+    "全問解答済み" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All questions answered"
+          }
+        }
+      }
+    },
+    "モデルのダウンロードが必要" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model download required"
+          }
+        }
+      }
+    },
+    "リセット" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reset"
+          }
+        }
+      }
+    },
+    "現在のスコア: %@" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current score: %@"
+          }
+        }
+      }
+    },
+    "次の問題へ" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next question"
+          }
+        }
+      }
+    },
+    "次の未解答の空欄まで本文をスクロールします" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scrolls the article to the next unanswered blank"
+          }
+        }
+      }
+    },
+    "正解" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correct"
+          }
+        }
+      }
+    },
+    "正解！" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Correct!"
+          }
+        }
+      }
+    },
+    "生成済みクイズを開く" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open generated quiz"
+          }
+        }
+      }
+    },
+    "空欄 {position}、不正解、答えは {answer}" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blank {position}, incorrect. The answer is {answer}"
+          }
+        }
+      }
+    },
+    "空欄 {position}、正解、答えは {answer}" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blank {position}, correct. The answer is {answer}"
+          }
+        }
+      }
+    },
+    "空欄 {position}、未解答" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blank {position}, unanswered"
+          }
+        }
+      }
+    },
+    "閉じる" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -41,12 +41,17 @@ struct ProposalQuizView: View {
     )
   }
 
+  /// 末尾が裸の % だと書式文字列として不正になるため、数値と記号をまとめて差し込む
+  private func percentText(_ percentage: Double) -> String {
+    "\(Int(percentage))%"
+  }
+
   var body: some View {
     VStack(spacing: 0) {
       if let currentScore = quizViewModel.currentScore {
         HStack {
           HStack {
-            Text("現在のスコア: \(Int(currentScore.percentage))%")
+            Text("現在のスコア: \(percentText(currentScore.percentage))")
               .font(AppFont.headline)
             Text("(\(currentScore.correctCount)/\(currentScore.totalCount)問正解)")
               .font(AppFont.subheadline)

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -45,11 +45,14 @@ struct ProposalQuizView: View {
     VStack(spacing: 0) {
       if let currentScore = quizViewModel.currentScore {
         HStack {
-          Text("現在のスコア: \(Int(currentScore.percentage))%")
-            .font(.headline)
-          Text("(\(currentScore.correctCount)/\(currentScore.totalCount)問正解)")
-            .font(AppFont.subheadline)
-            .foregroundStyle(.secondary)
+          HStack {
+            Text("現在のスコア: \(Int(currentScore.percentage))%")
+              .font(AppFont.headline)
+            Text("(\(currentScore.correctCount)/\(currentScore.totalCount)問正解)")
+              .font(AppFont.subheadline)
+              .foregroundStyle(.secondary)
+          }
+          .accessibilityElement(children: .combine)
           Spacer()
           Button(action: {
             quizViewModel.isShowingResetAlert = true
@@ -132,6 +135,7 @@ struct ProposalQuizView: View {
           }
         } label: {
           Image(systemName: "wand.and.stars")
+            .accessibilityLabel(quizViewModel.hasLLMQuizzes ? "生成済みクイズを開く" : "クイズを生成")
         }
       }
     }

--- a/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
@@ -21,6 +21,8 @@ struct QuizSelectionsView: View {
               Text(isCorrect ? "正解！" : "不正解...")
                 .font(AppFont.title)
                 .foregroundStyle(isCorrect ? SemanticColor.correct : SemanticColor.incorrect)
+                .accessibilityLabel(
+                  isCorrect ? "正解" : "不正解、答えは \(quiz.answer)")
             }
           }
           .frame(height: 32)
@@ -46,6 +48,7 @@ struct QuizSelectionsView: View {
       VStack(spacing: AppSpacing.sm) {
         Button("次の問題へ", action: viewModel.goToNextUnansweredQuiz)
           .buttonStyle(.glassProminent)
+          .accessibilityHint("次の未解答の空欄まで本文をスクロールします")
         Button("閉じる", action: viewModel.dismissQuiz)
       }
     } else {

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -365,7 +365,7 @@ private func parse(
                     const pattern = /(＿)+/g;
                     const wrappedText = text.replace(pattern, function(match) {
                         const index = currentIndex++;
-                        return `<span class="masked-word" data-mask-index="${index}" data-placeholder="${match}">${match}</span>`;
+                        return `<span class="masked-word" data-mask-index="${index}" data-placeholder="${match}" role="button" tabindex="0" lang="ja">${match}</span>`;
                     });
                     document.body.innerHTML = wrappedText;
                     renderQuizState();
@@ -374,14 +374,31 @@ private func parse(
                     }
                 }
 
+                function maskedWordLabel(key, answered, isCorrect, answer) {
+                    const position = Number(key) + 1;
+                    if (!answered) { return '空欄 ' + position + '、未解答'; }
+                    return '空欄 ' + position + '、' + (isCorrect ? '正解' : '不正解') + '、答えは ' + answer;
+                }
+
                 function renderQuizState() {
                     document.querySelectorAll('.masked-word').forEach(function(el) {
                         const key = el.dataset.maskIndex;
                         const answered = Object.prototype.hasOwnProperty.call(quizState.isCorrect, key);
-                        el.classList.toggle('correct', answered && quizState.isCorrect[key]);
-                        el.classList.toggle('incorrect', answered && !quizState.isCorrect[key]);
-                        el.classList.toggle('current', String(quizState.focused) === key);
+                        const isCorrect = answered && quizState.isCorrect[key];
+                        const isFocused = String(quizState.focused) === key;
+                        el.classList.toggle('correct', isCorrect);
+                        el.classList.toggle('incorrect', answered && !isCorrect);
+                        el.classList.toggle('current', isFocused);
                         el.textContent = answered ? quizState.answers[key] : el.dataset.placeholder;
+                        el.setAttribute(
+                            'aria-label',
+                            maskedWordLabel(key, answered, isCorrect, quizState.answers[key])
+                        );
+                        if (isFocused) {
+                            el.setAttribute('aria-current', 'true');
+                        } else {
+                            el.removeAttribute('aria-current');
+                        }
                     });
                     if (quizState.scrollTarget === null || quizState.scrollTarget === appliedScrollTarget) {
                         return;
@@ -478,17 +495,29 @@ extension DefaultWebView {
     let config = WKWebViewConfiguration()
     let userScript = WKUserScript(
       source: """
+        function maskedWordFrom(target) {
+            return target && target.closest ? target.closest('.masked-word') : null;
+        }
+
+        function postMaskedWordTap(element) {
+            window.webkit.messageHandlers.maskedWordTapped.postMessage({
+                maskIndex: parseInt(element.dataset.maskIndex)
+            });
+        }
+
         document.addEventListener('click', function(e) {
-            console.log('Click event detected:', e.target);
-            if (e.target.classList.contains('masked-word')) {
-                console.log('Masked word clicked:', e.target.dataset.maskIndex);
-                window.webkit.messageHandlers.maskedWordTapped.postMessage({
-                    maskIndex: parseInt(e.target.dataset.maskIndex)
-                });
-            }
+            const element = maskedWordFrom(e.target);
+            if (element) { postMaskedWordTap(element); }
         });
 
-        // Add scroll event listener
+        document.addEventListener('keydown', function(e) {
+            if (e.key !== 'Enter' && e.key !== ' ') { return; }
+            const element = maskedWordFrom(e.target);
+            if (!element) { return; }
+            e.preventDefault();
+            postMaskedWordTap(element);
+        });
+
         let scrollTimeout;
         window.addEventListener('scroll', function() {
             clearTimeout(scrollTimeout);

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -189,6 +189,18 @@ extension WKWebView {
   }
 }
 
+/// WebView 内のマスクは JavaScript が読み上げラベルを組み立てるため、
+/// 語順が言語で変わる分をプレースホルダ入りのテンプレートとして渡す。
+private struct MaskedWordLabels: Encodable {
+  let unanswered = String(localized: "空欄 {position}、未解答")
+  let correct = String(localized: "空欄 {position}、正解、答えは {answer}")
+  let incorrect = String(localized: "空欄 {position}、不正解、答えは {answer}")
+
+  var json: String {
+    (try? JSONEncoder().encode(self)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
+  }
+}
+
 private func jsonObject<Value: Encodable>(_ dictionary: [Int: Value]) -> String {
   (try? JSONEncoder().encode(dictionary)).flatMap { String(data: $0, encoding: .utf8) } ?? "{}"
 }
@@ -352,6 +364,7 @@ private func parse(
             <script>
                 let currentIndex = 0;
                 const initialScrollY = \(scrollContentOffsetY);
+                const quizLabels = \(MaskedWordLabels().json);
                 let quizState = {
                     isCorrect: \(isCorrectJSON),
                     answers: \(answersJSON),
@@ -375,9 +388,12 @@ private func parse(
                 }
 
                 function maskedWordLabel(key, answered, isCorrect, answer) {
-                    const position = Number(key) + 1;
-                    if (!answered) { return '空欄 ' + position + '、未解答'; }
-                    return '空欄 ' + position + '、' + (isCorrect ? '正解' : '不正解') + '、答えは ' + answer;
+                    const template = !answered
+                        ? quizLabels.unanswered
+                        : (isCorrect ? quizLabels.correct : quizLabels.incorrect);
+                    return template
+                        .replace('{position}', String(Number(key) + 1))
+                        .replace('{answer}', answer === undefined ? '' : answer);
                 }
 
                 function renderQuizState() {


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## 概要

**VoiceOver ユーザーがマスククイズを開始できない状態を修正する。**

マスクを表す `<span>` に `role` も `tabindex` も無く、クリックは `document` レベルのリスナーで拾っていた。そのため VoiceOver はマスクをボタンとして読み上げず、ローターでも辿れない。クイズの起点がスクリーンリーダーから見えないため、**機能全体が使えない状態**だった。

PR #61 のUI/UX専門レビューで指摘された項目のうち、深刻度が最も高いものを切り出した。

## 変更点

### マスクをボタンとして成立させる

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 要素の役割 | `<span>`（役割なし） | `role="button"` / `tabindex="0"` |
| 読み上げ | 「アンダースコア、アンダースコア…」 | 「空欄 3、正解、答えは async」 |
| フォーカス位置 | 視覚的なリングのみ | `aria-current="true"` |
| キーボード操作 | なし | Enter / Space |

`aria-label` は `setAttribute` で設定している。サーバー由来の解答テキストがHTML文字列連結を経由しないため、エスケープ漏れによる注入経路を作らずに済む。

本文は英語の提案文だが読み上げるラベルは日本語なので、`lang="ja"` を付けて英語音声で読まれないようにした。

### クリック判定を `closest()` に変える

```diff
- if (e.target.classList.contains('masked-word')) {
+ const element = target.closest('.masked-word');
```

変更前は `e.target` がマスクの `<span>` そのものでないと反応しなかった。キーボード操作の追加でハンドラを共通化する必要があったことに加え、今後タップ領域を疑似要素で 44pt へ広げる際に取りこぼす作りだったため、この機会に直した。

### SwiftUI 側の不足

- LLMクイズのツールバーボタン（`wand.and.stars`）に `accessibilityLabel` が無かった。状態に応じて「クイズを生成」「生成済みクイズを開く」を出し分ける
- スコア表示の2つの `Text` が個別に読まれていた。`accessibilityElement(children: .combine)` でまとめる
- 「次の問題へ」を押すと本文がスクロールすることが伝わらなかった。`accessibilityHint` を追加
- 不正解時に正解が読み上げられなかった。`accessibilityLabel` で「不正解、答えは X」と読む
- `ProposalQuizView:49` で `.font(.headline)` が生で使われていた。他はすべてデザイントークン経由のため `AppFont.headline` へ揃えた

## 多言語対応（日本語・英語）

**ローカライズの仕組みが存在せず、UI文字列がすべて直書きだった**ため、String Catalog を導入した。

- `Localizable.xcstrings` を追加し、`sourceLanguage` を `ja` に設定した
- プロジェクトの `developmentRegion` を `en` から `ja` へ変更し、`knownRegions` に `ja` を追加した。アプリは日本語で書かれているため、これが実態に合う

### WebView 内の読み上げラベル

aria-label は JavaScript が組み立てるため String Catalog を直接使えない。単語ごとに渡すと語順が言語で変わって破綻する（「空欄 3、正解、答えは async」と "Blank 3, correct. The answer is async" では順序が違う）。プレースホルダ入りの文をまるごと渡し、JS 側で置換する形にした。翻訳者が文全体を見て語順を決められる。

```swift
private struct MaskedWordLabels: Encodable {
  let unanswered = String(localized: "空欄 {position}、未解答")
  let correct = String(localized: "空欄 {position}、正解、答えは {answer}")
  let incorrect = String(localized: "空欄 {position}、不正解、答えは {answer}")
}
```

### 併せて直した書式文字列の不具合

`Text("現在のスコア: \(Int(percentage))%")` はキーが `"現在のスコア: %lld%"` となり、**末尾が裸の `%` で書式文字列として不正**だった。数値と記号をまとめて差し込み、キーを `"現在のスコア: %@"` にした。

### 対応範囲

`QuizSelectionsView` と `ProposalQuizView`、つまりクイズ解答画面を単位として23件を対応した。当初は本PRが追加した6文字列のみの予定だったが、同じ画面でボタンが英語・アラートが日本語になるのを避けるため画面ごと揃えた。

**アプリ全体では177文字列中23件**である。英語環境では一覧・設定・依存グラフなど他画面が日本語のまま残る。残りは別タスクとして扱う。

## 検証

- ユニットテスト全件パス（iPhone 17 シミュレータ）
- macOS ビルド成功
- `swift-complexity --threshold 10` 通過
- `swift-format lint` クリーン
- 変更した2つのJavaScriptブロックを `node --check` で構文検証
- **String Catalog の全23キーがソース上に実在することを機械的に照合した**。書式指定子とプレースホルダを除いた最長断片で検索する方式。カタログ作成中に実在しない文字列を混入させたため、チェックを書いて潰した

## レビューポイント

1. **`aria-label` の文言**。「空欄 3、正解、答えは async」という形式で読み上げる。番号は0始まりのindexに1を足している
2. **不正解時に正解を読み上げてよいか**。画面上も `textContent` が正解に置き換わるため表示と一致させたが、学習体験として妥当かは判断が要る

## 未実施の確認

**VoiceOver を有効にした実機確認ができていない。** マージ前に次を確認いただきたい。

1. VoiceOver でマスクがボタンとして読み上げられ、ローターで辿れるか
2. ダブルタップで解答パネルが開くか
3. 「次の問題へ」で移動したあと、移動先のマスクが `aria-current` として認識されるか
4. 外付けキーボードで Tab によるフォーカス移動と Enter/Space での解答ができるか
5. **英語ロケールで英語が表示されるか。** シミュレータの言語設定を English にするか、スキームの App Language を English にして確認する。ビルドが通っているため String Catalog の取り込み自体は成功しているが、実際の表示は未確認

## 関連

- PR #61 のUI/UX専門レビューから切り出した項目
- 残りの指摘（選択肢パネルの再設計、WebViewの基礎品質）は別PRで対応する
