### PR TITLE
改善: 選択肢パネルをボトムシート化し、高さを固定して残り問題数を表示する

### DIFF
--- a/ios/se-masked-quiz/DesignSystem/Components/QuizChoiceButton.swift
+++ b/ios/se-masked-quiz/DesignSystem/Components/QuizChoiceButton.swift
@@ -30,13 +30,11 @@ struct QuizChoiceButton: View {
         Text(title)
           .multilineTextAlignment(.leading)
           .frame(maxWidth: .infinity, alignment: .leading)
-        if state == .correct {
-          Image(systemName: "checkmark.circle.fill")
-            .foregroundStyle(SemanticColor.correct)
-        } else if state == .incorrectSelected {
-          Image(systemName: "xmark.circle.fill")
-            .foregroundStyle(SemanticColor.incorrect)
-        }
+        // 正誤確定時にアイコンを挿入するとタイトルが再フローするため、枠は常に確保する
+        Image(systemName: iconName)
+          .foregroundStyle(iconColor)
+          .opacity(showsIcon ? 1 : 0)
+          .contentTransition(.symbolEffect(.replace))
       }
       .padding()
       .background(backgroundColor)
@@ -44,9 +42,27 @@ struct QuizChoiceButton: View {
       .clipShape(RoundedRectangle(cornerRadius: AppRadius.medium))
       .animation(.easeInOut(duration: 0.2), value: state)
     }
-    .disabled(isAnswered)
+    // disabled にすると結果表示まで減光され、どれが正解か分かりにくくなる
+    .allowsHitTesting(!isAnswered)
     .accessibilityLabel(title)
     .accessibilityValue(accessibilityValue)
+    .accessibilityRemoveTraits(isAnswered ? .isButton : [])
+  }
+
+  private var showsIcon: Bool {
+    state == .correct || state == .incorrectSelected
+  }
+
+  private var iconName: String {
+    switch state {
+    case .correct: return "checkmark.circle.fill"
+    case .incorrectSelected: return "xmark.circle.fill"
+    case .unanswered, .incorrectOther: return "circle"
+    }
+  }
+
+  private var iconColor: Color {
+    state == .correct ? SemanticColor.correct : SemanticColor.incorrect
   }
 
   private var backgroundColor: Color {

--- a/ios/se-masked-quiz/Localizable.xcstrings
+++ b/ios/se-masked-quiz/Localizable.xcstrings
@@ -1,259 +1,270 @@
 {
-  "sourceLanguage" : "ja",
-  "strings" : {
-    "(%lld/%lld問正解)" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "(%lld/%lld correct)"
+  "sourceLanguage": "ja",
+  "strings": {
+    "%lld/%lld問": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld of %lld"
           }
         }
       }
     },
-    "LLMクイズを生成するには、設定画面からモデルをダウンロードしてください。" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To generate LLM quizzes, download a model from Settings."
+    "(%lld/%lld問正解)": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "(%lld/%lld correct)"
           }
         }
       }
     },
-    "このプロポーザルのクイズの進捗をリセットしますか？\nこの操作は取り消せません。" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset your quiz progress for this proposal?\nThis action cannot be undone."
+    "LLMクイズを生成するには、設定画面からモデルをダウンロードしてください。": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "To generate LLM quizzes, download a model from Settings."
           }
         }
       }
     },
-    "キャンセル" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
+    "このプロポーザルのクイズの進捗をリセットしますか？\nこの操作は取り消せません。": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset your quiz progress for this proposal?\nThis action cannot be undone."
           }
         }
       }
     },
-    "クイズをリセット" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset quiz"
+    "キャンセル": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel"
           }
         }
       }
     },
-    "クイズを生成" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Generate quiz"
+    "クイズをリセット": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset quiz"
           }
         }
       }
     },
-    "不正解、答えは %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incorrect. The answer is %@"
+    "クイズを生成": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Generate quiz"
           }
         }
       }
     },
-    "不正解..." : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Incorrect..."
+    "クイズを閉じる": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close quiz"
           }
         }
       }
     },
-    "依存グラフ" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dependency graph"
+    "モデルのダウンロードが必要": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Model download required"
           }
         }
       }
     },
-    "先に読むと理解しやすい提案" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proposals worth reading first"
+    "リセット": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reset"
           }
         }
       }
     },
-    "全問解答済み" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All questions answered"
+    "不正解": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect"
           }
         }
       }
     },
-    "モデルのダウンロードが必要" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model download required"
+    "不正解、答えは %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incorrect. The answer is %@"
           }
         }
       }
     },
-    "リセット" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset"
+    "依存グラフ": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dependency graph"
           }
         }
       }
     },
-    "現在のスコア: %@" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Current score: %@"
+    "先に読むと理解しやすい提案": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Proposals worth reading first"
           }
         }
       }
     },
-    "次の問題へ" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Next question"
+    "全問解答済み": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All questions answered"
           }
         }
       }
     },
-    "次の未解答の空欄まで本文をスクロールします" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scrolls the article to the next unanswered blank"
+    "次の問題へ": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Next question"
           }
         }
       }
     },
-    "正解" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Correct"
+    "次の未解答の空欄まで本文をスクロールします": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Scrolls the article to the next unanswered blank"
           }
         }
       }
     },
-    "正解！" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Correct!"
+    "正解": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Correct"
           }
         }
       }
     },
-    "生成済みクイズを開く" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open generated quiz"
+    "現在のスコア: %@": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current score: %@"
           }
         }
       }
     },
-    "空欄 {position}、不正解、答えは {answer}" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blank {position}, incorrect. The answer is {answer}"
+    "生成済みクイズを開く": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open generated quiz"
           }
         }
       }
     },
-    "空欄 {position}、正解、答えは {answer}" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blank {position}, correct. The answer is {answer}"
+    "空欄 {position}、不正解、答えは {answer}": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank {position}, incorrect. The answer is {answer}"
           }
         }
       }
     },
-    "空欄 {position}、未解答" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Blank {position}, unanswered"
+    "空欄 {position}、未解答": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank {position}, unanswered"
           }
         }
       }
     },
-    "閉じる" : {
-      "extractionState" : "manual",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close"
+    "空欄 {position}、正解、答えは {answer}": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Blank {position}, correct. The answer is {answer}"
+          }
+        }
+      }
+    },
+    "閉じる": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
           }
         }
       }
     }
   },
-  "version" : "1.0"
+  "version": "1.0"
 }

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -106,9 +106,15 @@ struct ProposalQuizView: View {
         scrollToMaskIndex: quizViewModel.pendingScrollMaskIndex,
         focusedMaskIndex: quizViewModel.currentQuiz?.index
       )
-      if quizViewModel.currentQuiz != nil {
-        QuizSelectionsView(viewModel: quizViewModel)
+      // VStack の兄弟にするとパネルの表示のたびにWebViewが縮んで本文が再レイアウトされる
+      .safeAreaInset(edge: .bottom, spacing: 0) {
+        if quizViewModel.currentQuiz != nil {
+          QuizSelectionsView(viewModel: quizViewModel)
+            .padding(.bottom, AppSpacing.sm)
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
       }
+      .animation(.snappy, value: quizViewModel.currentQuiz?.index)
     }
     .navigationTitle(proposal.title)
     #if os(iOS)

--- a/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/ProposalQuizView.swift
@@ -46,6 +46,15 @@ struct ProposalQuizView: View {
     "\(Int(percentage))%"
   }
 
+  private var isShowingQuizSheet: Binding<Bool> {
+    Binding(
+      get: { quizViewModel.currentQuiz != nil },
+      set: { isShowing in
+        if !isShowing { quizViewModel.dismissQuiz() }
+      }
+    )
+  }
+
   var body: some View {
     VStack(spacing: 0) {
       if let currentScore = quizViewModel.currentScore {
@@ -106,15 +115,15 @@ struct ProposalQuizView: View {
         scrollToMaskIndex: quizViewModel.pendingScrollMaskIndex,
         focusedMaskIndex: quizViewModel.currentQuiz?.index
       )
-      // VStack の兄弟にするとパネルの表示のたびにWebViewが縮んで本文が再レイアウトされる
-      .safeAreaInset(edge: .bottom, spacing: 0) {
-        if quizViewModel.currentQuiz != nil {
-          QuizSelectionsView(viewModel: quizViewModel)
-            .padding(.bottom, AppSpacing.sm)
-            .transition(.move(edge: .bottom).combined(with: .opacity))
-        }
+      // item: 版は問題を移動するたびに閉じて開き直すため、表示状態は Bool で持つ
+      .sheet(isPresented: isShowingQuizSheet) {
+        QuizSelectionsView(viewModel: quizViewModel)
+          .presentationDetents([.medium, .large])
+          .presentationDragIndicator(.visible)
+          .presentationBackground(.regularMaterial)
+          .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+          .presentationCornerRadius(AppRadius.extraLarge * 2)
       }
-      .animation(.snappy, value: quizViewModel.currentQuiz?.index)
     }
     .navigationTitle(proposal.title)
     #if os(iOS)

--- a/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
@@ -4,8 +4,10 @@ struct QuizSelectionsView: View {
   @ObservedObject var viewModel: QuizViewModel
 
   var body: some View {
-    VStack(spacing: 12) {
-      if let quiz = viewModel.currentQuiz {
+    if let quiz = viewModel.currentQuiz {
+      VStack(spacing: AppSpacing.md) {
+        header(for: quiz)
+
         ForEach(quiz.allChoices, id: \.self) { choice in
           QuizChoiceButton(
             title: choice,
@@ -15,50 +17,88 @@ struct QuizSelectionsView: View {
           }
         }
 
-        VStack {
-          VStack {
-            if let isCorrect = viewModel.isCorrect[quiz.index] {
-              Text(isCorrect ? "正解！" : "不正解...")
-                .font(AppFont.title)
-                .foregroundStyle(isCorrect ? SemanticColor.correct : SemanticColor.incorrect)
-                .accessibilityLabel(
-                  isCorrect ? "正解" : "不正解、答えは \(quiz.answer)")
-            }
-          }
-          .frame(height: 32)
-          footer(for: quiz)
-            .padding(AppSpacing.xs)
-        }
+        primaryAction(for: quiz)
       }
+      .padding(AppSpacing.lg)
+      .glassCard(cornerRadius: AppRadius.extraLarge)
+      .padding(.horizontal, AppSpacing.md)
+      .animation(.snappy, value: viewModel.isCorrect[quiz.index])
+      .sensoryFeedback(trigger: viewModel.isCorrect[quiz.index]) { _, newValue in
+        guard let isCorrect = newValue else { return nil }
+        return isCorrect ? .success : .error
+      }
+      .sensoryFeedback(.selection, trigger: viewModel.pendingScrollMaskIndex)
     }
-    .padding(AppSpacing.lg)
-    .sensoryFeedback(trigger: viewModel.currentQuiz.map { viewModel.isCorrect[$0.index] }) {
-      _, newValue in
-      guard let isCorrect = newValue ?? nil else { return nil }
-      return isCorrect ? .success : .error
-    }
-    .sensoryFeedback(.selection, trigger: viewModel.pendingScrollMaskIndex)
   }
 
-  @ViewBuilder
-  private func footer(for quiz: Quiz) -> some View {
-    if viewModel.isCorrect[quiz.index] == nil {
-      Button("閉じる", action: viewModel.dismissQuiz)
-    } else if viewModel.nextUnansweredMaskIndex != nil {
-      VStack(spacing: AppSpacing.sm) {
-        Button("次の問題へ", action: viewModel.goToNextUnansweredQuiz)
-          .buttonStyle(.glassProminent)
-          .accessibilityHint("次の未解答の空欄まで本文をスクロールします")
-        Button("閉じる", action: viewModel.dismissQuiz)
+  private var answeredCount: Int { viewModel.isCorrect.count }
+  private var totalCount: Int { viewModel.allQuiz.count }
+  private var isAllAnswered: Bool { totalCount > 0 && answeredCount >= totalCount }
+
+  private func header(for quiz: Quiz) -> some View {
+    HStack(spacing: AppSpacing.sm) {
+      Group {
+        if isAllAnswered {
+          Text("全問解答済み")
+            .foregroundStyle(SemanticColor.correct)
+        } else {
+          Text("\(answeredCount)/\(totalCount)問")
+            .foregroundStyle(.secondary)
+        }
       }
-    } else {
-      VStack(spacing: AppSpacing.sm) {
-        Text("全問解答済み")
-          .font(AppFont.headline)
-          .foregroundStyle(SemanticColor.correct)
-        Button("閉じる", action: viewModel.dismissQuiz)
+      .font(AppFont.subheadline)
+      .monospacedDigit()
+
+      Spacer()
+
+      resultLabel(for: quiz)
+
+      Button(action: viewModel.dismissQuiz) {
+        Image(systemName: "xmark.circle.fill")
+          .font(AppFont.title)
+          .foregroundStyle(.secondary)
+          .frame(minWidth: 44, minHeight: 44)
+          .contentShape(Rectangle())
       }
+      .buttonStyle(.plain)
+      .accessibilityLabel("クイズを閉じる")
     }
+  }
+
+  /// 未解答時も opacity で場所を確保する。表示・非表示で高さが変わると
+  /// 直前に押したボタンの位置がずれるため
+  private func resultLabel(for quiz: Quiz) -> some View {
+    let isCorrect = viewModel.isCorrect[quiz.index]
+    return Label(
+      isCorrect == true ? "正解" : "不正解",
+      systemImage: isCorrect == true ? "checkmark.circle.fill" : "xmark.circle.fill"
+    )
+    .font(AppFont.headline)
+    .foregroundStyle(isCorrect == true ? SemanticColor.correct : SemanticColor.incorrect)
+    .opacity(isCorrect == nil ? 0 : 1)
+    .accessibilityLabel(isCorrect == true ? "正解" : "不正解、答えは \(quiz.answer)")
+    .accessibilityHidden(isCorrect == nil)
+  }
+
+  private func primaryAction(for quiz: Quiz) -> some View {
+    let isAnswered = viewModel.isCorrect[quiz.index] != nil
+    let hasNext = viewModel.nextUnansweredMaskIndex != nil
+    return Button {
+      if hasNext {
+        viewModel.goToNextUnansweredQuiz()
+      } else {
+        viewModel.dismissQuiz()
+      }
+    } label: {
+      Text(hasNext ? "次の問題へ" : "閉じる")
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.glassProminent)
+    .controlSize(.large)
+    .opacity(isAnswered ? 1 : 0)
+    .disabled(!isAnswered)
+    .accessibilityHidden(!isAnswered)
+    .accessibilityHint(hasNext ? "次の未解答の空欄まで本文をスクロールします" : "")
   }
 
   private func choiceState(for choice: String, quiz: Quiz) -> ChoiceState {

--- a/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
+++ b/ios/se-masked-quiz/ProposalFeature/QuizSelectionsView.swift
@@ -5,23 +5,24 @@ struct QuizSelectionsView: View {
 
   var body: some View {
     if let quiz = viewModel.currentQuiz {
-      VStack(spacing: AppSpacing.md) {
-        header(for: quiz)
+      ScrollView {
+        VStack(spacing: AppSpacing.md) {
+          header(for: quiz)
 
-        ForEach(quiz.allChoices, id: \.self) { choice in
-          QuizChoiceButton(
-            title: choice,
-            state: choiceState(for: choice, quiz: quiz)
-          ) {
-            viewModel.selectAnswer(choice)
+          ForEach(quiz.allChoices, id: \.self) { choice in
+            QuizChoiceButton(
+              title: choice,
+              state: choiceState(for: choice, quiz: quiz)
+            ) {
+              viewModel.selectAnswer(choice)
+            }
           }
-        }
 
-        primaryAction(for: quiz)
+          primaryAction(for: quiz)
+        }
+        .padding(AppSpacing.lg)
       }
-      .padding(AppSpacing.lg)
-      .glassCard(cornerRadius: AppRadius.extraLarge)
-      .padding(.horizontal, AppSpacing.md)
+      .scrollBounceBehavior(.basedOnSize)
       .animation(.snappy, value: viewModel.isCorrect[quiz.index])
       .sensoryFeedback(trigger: viewModel.isCorrect[quiz.index]) { _, newValue in
         guard let isCorrect = newValue else { return nil }

--- a/ios/se-masked-quiz/Views/DefaultWebView.swift
+++ b/ios/se-masked-quiz/Views/DefaultWebView.swift
@@ -325,6 +325,8 @@ private func parse(
                     position: relative;
                     touch-action: manipulation;
                     -webkit-tap-highlight-color: transparent;
+                    /* 下部の選択肢パネルに隠れない高さへ着地させる */
+                    scroll-margin-top: 30vh;
                 }
                 .masked-word.correct {
                     color: #fff;
@@ -422,7 +424,7 @@ private func parse(
                     const target = document.querySelector('[data-mask-index="' + quizState.scrollTarget + '"]');
                     if (!target) { return; }
                     appliedScrollTarget = quizState.scrollTarget;
-                    target.scrollIntoView({ block: 'center' });
+                    target.scrollIntoView({ block: 'start' });
                     target.classList.remove('pulse');
                     void target.offsetWidth;
                     target.classList.add('pulse');


### PR DESCRIPTION
<!-- GitHub Copilot code reviewへの指示: コードレビューの結果は日本語で出力してください。例外はありません。 -->

## 概要

選択肢パネルの高さが状態によって変わる問題と、残り問題数が表示されない問題を解消する。PR #61 のUI/UX専門レビューで指摘された項目のうち、パネル周りをまとめて対応した。

## 解決する問題

### 1. 押したばかりのボタンが動く（体感品質の主因）

パネルは3状態でボタン数が変わっていた。

| 状態 | 従来の表示 |
|---|---|
| 未解答 | 「閉じる」1つ |
| 解答済み・次あり | 「次の問題へ」＋「閉じる」の2つ |
| 全問解答済み | 「全問解答済み」テキスト＋「閉じる」 |

選択肢をタップした瞬間にパネル全体が伸び、**いま押したばかりのボタンの位置がずれる**。体感品質を最も損なうタイプの挙動だった。

正誤ラベルと主ボタンを `opacity` で出し分け、場所は常に確保することで3状態すべてで高さを一定にした。

### 2. `.frame(height: 32)` が Dynamic Type で破綻する（実バグ）

正誤表示を高さ32ptの固定枠に入れていた。`AppFont.title` は `Font.title2.weight(.bold)`（既定22pt、行高28pt前後）で既定サイズでもギリギリ、アクセシビリティサイズでは32ptを超える。`.frame` はクリップしないため、**はみ出した分が下のボタンと重なる**。

固定枠を撤去した。

### 3. 残り問題数がどこにも出ない（情報設計の穴）

`ProposalScore.totalCount` は `questionResults.count`、つまり**解答済みの問題数**を返す。そのため全20問のうち1問目に正解した直後は「現在のスコア: 100% (1/1問正解)」と表示され、残り19問あることが分からない。

「次へ」で連続的に解き進めるフローにした以上あと何問あるかは必須の情報なので、パネルのヘッダーに `解答済み/全問` を表示した。全問解答時は「全問解答済み」に切り替えるため、行数は増えていない。

### 4. 解答後に正解が見分けにくい

`QuizChoiceButton` の `.disabled(isAnswered)` により、解答後は全選択肢が減光される。正解の背景 `SemanticColor.correct.opacity(0.2)` がさらに薄まり、どれが正解か分かりにくくなっていた。

解答後のパネルは操作対象ではなく結果表示なので、`allowsHitTesting(!isAnswered)` に変えた。VoiceOver 向けには解答後に `.isButton` トレイトを外す。

### 5. アイコン挿入でタイトルが再フローする

`QuizChoiceButton` のチェック/バツは正誤確定時に初めて `HStack` へ挿入されるため、タイトルの折り返し位置が変わる。アイコン枠を常に確保して解消した。

### 6. パネル表示のたびに本文が再レイアウトされる → ボトムシート化

`VStack` の兄弟に置いていたため、パネルが出るたびに WebView のフレームが縮み、WKWebView 側でレイアウト再計算が走っていた。

**下部にフローティングするカードにしたいという要望を受け、`.sheet` によるボトムシートへ変更した。**

```swift
.sheet(isPresented: isShowingQuizSheet) {
  QuizSelectionsView(viewModel: quizViewModel)
    .presentationDetents([.medium, .large])
    .presentationDragIndicator(.visible)
    .presentationBackground(.regularMaterial)
    .presentationBackgroundInteraction(.enabled(upThrough: .medium))
    .presentationCornerRadius(AppRadius.extraLarge * 2)
}
```

**`.sheet(item:)` ではなく `isPresented` を使っている。** `item:` 版はアイテムの identity が変わるとシートを閉じて開き直すため、「次の問題へ」を押すたびにシートがフラッシュしてしまう。表示状態を `Bool` で持ち、中身は `currentQuiz` を読む形にすれば、問題移動は内容の更新だけで済む。

**`presentationBackgroundInteraction` は必須である。** これがないとシートが本文をブロックし、自動スクロールしても本文を読めないため、文脈を確認しながら解答するという機能そのものが成立しない。

パネル側は `ScrollView` + `.scrollBounceBehavior(.basedOnSize)` で包んだ。Dynamic Type を大きくすると medium detent に収まらなくなるため、その場合だけスクロールできるようにしている。シートが背景を持つので `glassCard` は適用していない。

## スクロール着地点の変更（要確認）

シートは本文の上に重なるため WebView は全高を保つ。従来の `scrollIntoView({block: 'center'})` では**マスクがシートの裏に隠れる**恐れがある。JavaScript は画面上のシートの存在を知らないため、ビューポート中央がシートの裏になりうる。

```diff
- target.scrollIntoView({ block: 'center' });
+ target.scrollIntoView({ block: 'start' });
```
```css
.masked-word { scroll-margin-top: 30vh; }
```

30vh は「パネルが画面下半分を占めても隠れない」想定で置いた値である。**実機で未検証のため、レビュー時に確認いただきたい。**

## 多言語対応

新規文言3件（`クイズを閉じる` / `%lld/%lld問` / `不正解`）を String Catalog に追加した。設計変更で使わなくなった2件（`正解！` / `不正解...`）は削除した。全24キーがソース上に実在することを機械照合で確認済み。

## 検証

- ユニットテスト全件パス（iPhone 17 シミュレータ）
- macOS ビルド成功
- `swift-complexity --threshold 10` 通過
- `swift-format lint` クリーン
- String Catalog の全キーの実在を機械照合

## 未実施の確認

UI変更が中心のため、**実機での目視確認が必須**である。

1. **スクロール着地点**: 「次へ」で移動したマスクがシートの裏に隠れないか。`scroll-margin-top: 30vh` が妥当な値か
2. **detent の高さ**: `.medium`（画面の約50%）にヘッダー＋選択肢3〜4個＋主ボタンが収まるか。収まらない場合は `.fraction(0.55)` 等へ調整する
3. **背後の操作**: シート表示中に本文をスクロールできるか（`presentationBackgroundInteraction` が効いているか）
4. **問題移動時の挙動**: 「次の問題へ」でシートが閉じ開きせず、内容だけ切り替わるか
5. **高さの固定**: 選択肢をタップしたときにボタンの位置がずれないか
6. **Dynamic Type**: 最大サイズで文字が重ならないか。シート内でスクロールできるか
7. 英語ロケールでの表示

### macOS について

`presentationDetents` と `presentationBackgroundInteraction` は iOS 専用の API である。ビルドは通っているが、macOS では detent の概念がないため**画面中央のウィンドウとして表示される**はずで、「下部にフローティング」という見た目にはならない。今回は iOS の体験を主眼としており、macOS は機能が使える状態であれば許容とした。見た目も揃える必要がある場合は別途対応する。

## 関連

- PR #61 のUI/UX専門レビューから切り出した項目
- 残りの指摘（WebViewの基礎品質: ズーム禁止、CDN待ち、タップ領域44pt未満など）は別PRで対応する
